### PR TITLE
Fix image width and modal

### DIFF
--- a/web/app/components/product-item/index.jsx
+++ b/web/app/components/product-item/index.jsx
@@ -13,7 +13,7 @@ const ProductItem = ({
     image,
     price,
     title,
-    widthPercentage
+    customWidth
 }) => {
     const classes = classNames('c-product-item', 'u-flexbox', 'u-row-reverse', className)
 
@@ -43,7 +43,7 @@ const ProductItem = ({
 
 
             {image &&
-                <div className="u-padding-end u-flex-none" style={{width: widthPercentage}}>
+                <div className="u-padding-end u-flex-none" style={{width: customWidth}}>
                     {image}
                 </div>
             }
@@ -84,9 +84,9 @@ ProductItem.propTypes = {
     price: PropTypes.node,
 
     /**
-     * Designates the image width
+     * Designates the custom width that accepets valid css units
      */
-    widthPercentage: PropTypes.string
+    customWidth: PropTypes.string
 }
 
 export default ProductItem

--- a/web/app/components/product-item/index.jsx
+++ b/web/app/components/product-item/index.jsx
@@ -13,6 +13,7 @@ const ProductItem = ({
     image,
     price,
     title,
+    widthPercentage
 }) => {
     const classes = classNames('c-product-item', 'u-flexbox', 'u-row-reverse', className)
 
@@ -42,7 +43,7 @@ const ProductItem = ({
 
 
             {image &&
-                <div className="u-padding-end u-flex-none">
+                <div className="u-padding-end u-flex-none" style={{width:widthPercentage}}>
                     {image}
                 </div>
             }
@@ -81,6 +82,11 @@ ProductItem.propTypes = {
      * Designates the ProductItem's unit price
      */
     price: PropTypes.node,
+
+    /**
+     * Designates the image width
+     */
+    widthPercentage: PropTypes.string
 }
 
 export default ProductItem

--- a/web/app/components/product-item/index.jsx
+++ b/web/app/components/product-item/index.jsx
@@ -43,7 +43,7 @@ const ProductItem = ({
 
 
             {image &&
-                <div className="u-padding-end u-flex-none" style={{width:widthPercentage}}>
+                <div className="u-padding-end u-flex-none" style={{width: widthPercentage}}>
                     {image}
                 </div>
             }

--- a/web/app/components/product-item/index.jsx
+++ b/web/app/components/product-item/index.jsx
@@ -74,6 +74,11 @@ ProductItem.propTypes = {
     className: PropTypes.string,
 
     /**
+     * Designates the custom width that accepets valid css units
+     */
+    customWidth: PropTypes.string,
+
+    /**
      * Image of the product. Usually an `<img />` tag or `<Image />` component
      */
     image: PropTypes.node,
@@ -81,12 +86,7 @@ ProductItem.propTypes = {
     /**
      * Designates the ProductItem's unit price
      */
-    price: PropTypes.node,
-
-    /**
-     * Designates the custom width that accepets valid css units
-     */
-    customWidth: PropTypes.string
+    price: PropTypes.node
 }
 
 export default ProductItem

--- a/web/app/containers/cart/partials/cart-product-list.jsx
+++ b/web/app/containers/cart/partials/cart-product-list.jsx
@@ -74,7 +74,7 @@ class CartProductItem extends React.Component {
         } = this.props
 
         return (
-            <ProductItem widthPercentage="40%"
+            <ProductItem customWidth="40%"
                 className={productItemClassNames}
                 title={<h2 className="u-h5 u-text-font-family u-text-semi-bold">{product_name}</h2>}
                 image={<ProductImage {...product_image} />}

--- a/web/app/containers/cart/partials/cart-product-list.jsx
+++ b/web/app/containers/cart/partials/cart-product-list.jsx
@@ -74,7 +74,7 @@ class CartProductItem extends React.Component {
         } = this.props
 
         return (
-            <ProductItem
+            <ProductItem widthPercentage="40%"
                 className={productItemClassNames}
                 title={<h2 className="u-h5 u-text-font-family u-text-semi-bold">{product_name}</h2>}
                 image={<ProductImage {...product_image} />}

--- a/web/app/containers/checkout-payment/partials/payment-product-item.jsx
+++ b/web/app/containers/checkout-payment/partials/payment-product-item.jsx
@@ -28,7 +28,7 @@ const PaymentProductItem = ({
     )
 
     return (
-        <ProductItem
+        <ProductItem widthPercentage="20%"
             className="u-padding-top-lg u-padding-bottom-lg u-padding-start u-padding-end"
             title={<h2 className="u-h5">{product_name}</h2>}
             image={productImage}

--- a/web/app/containers/checkout-payment/partials/payment-product-item.jsx
+++ b/web/app/containers/checkout-payment/partials/payment-product-item.jsx
@@ -28,7 +28,7 @@ const PaymentProductItem = ({
     )
 
     return (
-        <ProductItem widthPercentage="20%"
+        <ProductItem customWidth="20%"
             className="u-padding-top-lg u-padding-bottom-lg u-padding-start u-padding-end"
             title={<h2 className="u-h5">{product_name}</h2>}
             image={productImage}

--- a/web/app/containers/product-details/_product-details.scss
+++ b/web/app/containers/product-details/_product-details.scss
@@ -37,6 +37,10 @@
         display: flex;
         flex-direction: column;
     }
+
+    .pw-sheet__wrapper {
+        justify-content: flex-end;
+    }
 }
 
 .t-product-details__item-added-modal-close {

--- a/web/app/containers/product-details/partials/product-details-item-added-modal.jsx
+++ b/web/app/containers/product-details/partials/product-details-item-added-modal.jsx
@@ -14,7 +14,7 @@ import ProductItem from '../../../components/product-item'
 import Sheet from 'progressive-web-sdk/dist/components/sheet'
 
 const ProductDetailsItemAddedModal = ({open, onDismiss, quantity, title, price, productImage, onGoToCheckout}) => (
-    <Sheet open={open} onDismiss={onDismiss} effect="slide-bottom" className="product-list__item-added-modal" coverage="50%">
+    <Sheet open={open} onDismiss={onDismiss} effect="slide-bottom" className="t-product-details__item-added-modal" coverage="50%" shrinkToContent>
         {/* Modal header */}
         <div className="u-flex-none u-border-bottom">
             <div className="u-flexbox u-align-center">
@@ -33,7 +33,7 @@ const ProductDetailsItemAddedModal = ({open, onDismiss, quantity, title, price, 
         <div className="u-flexbox u-column u-flex u-padding-md">
             {/* Modal product information */}
             <div className="u-flex u-margin-bottom-md">
-                <ProductItem
+                <ProductItem widthPercentage="20%"
                     title={<h2 className="c-h4">{title}</h2>}
                     image={<img role="presentation" src={productImage} alt="" width="60px" />}
                 >

--- a/web/app/containers/product-details/partials/product-details-item-added-modal.jsx
+++ b/web/app/containers/product-details/partials/product-details-item-added-modal.jsx
@@ -33,7 +33,7 @@ const ProductDetailsItemAddedModal = ({open, onDismiss, quantity, title, price, 
         <div className="u-flexbox u-column u-flex u-padding-md">
             {/* Modal product information */}
             <div className="u-flex u-margin-bottom-md">
-                <ProductItem widthPercentage="20%"
+                <ProductItem customWidth="20%"
                     title={<h2 className="c-h4">{title}</h2>}
                     image={<img role="presentation" src={productImage} alt="" width="60px" />}
                 >

--- a/web/app/containers/product-list/partials/product-tile.jsx
+++ b/web/app/containers/product-list/partials/product-tile.jsx
@@ -31,7 +31,7 @@ const ProductTile = ({className, image, link, price}) => {
 
     return (
         <ListTile className="t-product-list__product-tile u-card" {...link}>
-            <ProductItem
+            <ProductItem widthPercentage="45%"
                 {...image}
                 className={classNames('u-align-center', className)}
                 title={title}

--- a/web/app/containers/product-list/partials/product-tile.jsx
+++ b/web/app/containers/product-list/partials/product-tile.jsx
@@ -31,7 +31,7 @@ const ProductTile = ({className, image, link, price}) => {
 
     return (
         <ListTile className="t-product-list__product-tile u-card" {...link}>
-            <ProductItem widthPercentage="45%"
+            <ProductItem customWidth="45%"
                 {...image}
                 className={classNames('u-align-center', className)}
                 title={title}


### PR DESCRIPTION
Cart product card’s columns not set as per mocks, should be % width so that the image gets bigger on larger devices

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1245

## Changes
- add a prop to product item for width% and make modal shrink to content

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- go to PDP and add an item to cart
