### PR TITLE
fix width for right and left modals

### DIFF
--- a/web/app/containers/cart/partials/cart-estimate-shipping.jsx
+++ b/web/app/containers/cart/partials/cart-estimate-shipping.jsx
@@ -18,7 +18,7 @@ import {HeaderBar, HeaderBarActions, HeaderBarTitle} from 'progressive-web-sdk/d
 
 export const CartEstimateShippingModal = ({closeModal, isOpen, countries, stateProvinces, submitEstimateShipping, handleSubmit}) => {
     return (
-        <Sheet className="t-cart__estimate-shipping-modal" open={isOpen} onDismiss={closeModal} maskOpacity={0.7} effect="slide-right">
+        <Sheet className="t-cart__estimate-shipping-modal" open={isOpen} onDismiss={closeModal} maskOpacity={0.7} effect="slide-right" coverage="85%">
             <HeaderBar>
                 <HeaderBarTitle className="u-flex u-padding-start u-text-align-start">
                     <h1 className="u-h4 u-heading-family u-text-uppercase">

--- a/web/app/containers/mini-cart/container.js
+++ b/web/app/containers/mini-cart/container.js
@@ -67,7 +67,7 @@ class MiniCart extends React.Component {
         const {hasItems, contentsLoaded, isOpen, closeMiniCart} = this.props
 
         return (
-            <Sheet className="t-mini-cart" open={isOpen} onDismiss={closeMiniCart} maskOpacity={0.7} effect="slide-right">
+            <Sheet className="t-mini-cart" open={isOpen} onDismiss={closeMiniCart} maskOpacity={0.7} effect="slide-right" coverage="85%">
                 <MiniCartHeader closeMiniCart={closeMiniCart} />
 
                 {contentsLoaded && <MiniCartMain hasItems={hasItems} closeMiniCart={closeMiniCart} />}

--- a/web/app/containers/navigation/_navigation.scss
+++ b/web/app/containers/navigation/_navigation.scss
@@ -1,12 +1,6 @@
 // Navigation
 // ===
 
-.t-navigation {
-    .c-sheet__wrapper {
-        width: calc(100vw - #{$unit*5.5});
-    }
-}
-
 
 // Title
 // ---

--- a/web/app/containers/navigation/container.js
+++ b/web/app/containers/navigation/container.js
@@ -43,7 +43,7 @@ const Navigation = (props) => {
     }
 
     return (
-        <Sheet className="t-navigation" open={isOpen} onDismiss={closeNavigation} maskOpacity={0.7}>
+        <Sheet className="t-navigation" open={isOpen} onDismiss={closeNavigation} maskOpacity={0.7} coverage="85%">
             <Nav root={root.title ? root : null} path={path} onPathChange={onPathChange}>
                 <HeaderBar>
                     <HeaderBarTitle className="u-flex u-padding-start u-text-align-start">

--- a/web/app/styles/themes/pw-components/_sheet.scss
+++ b/web/app/styles/themes/pw-components/_sheet.scss
@@ -22,6 +22,26 @@
 }
 
 
+// Inner
+// ---
+// 1. requested by designer
+
+.pw--slide-right,
+.pw--slide-left {
+    .pw-sheet__inner {
+        max-width: 340px; // 1
+    }
+}
+
+.pw--slide-right {
+    .pw-sheet__inner {
+        left: initial;
+
+        width: 100%;
+    }
+}
+
+
 // States
 // ---
 //

--- a/web/app/styles/themes/pw-components/_sheet.scss
+++ b/web/app/styles/themes/pw-components/_sheet.scss
@@ -25,19 +25,21 @@
 // Inner
 // ---
 // 1. requested by designer
+// 2. to make modal stay on right of the container
+// 3. to cover the available space since it's absolute positioned
 
-.pw--slide-right,
-.pw--slide-left {
+.pw-sheet.pw--slide-right,
+.pw-sheet.pw--slide-left {
     .pw-sheet__inner {
         max-width: 340px; // 1
     }
 }
 
-.pw--slide-right {
+.pw-sheet.pw--slide-right {
     .pw-sheet__inner {
-        left: initial;
+        left: initial; // 2
 
-        width: 100%;
+        width: 100%; // 3
     }
 }
 


### PR DESCRIPTION
fix width for right and left modals

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1245

## Changes
- Change to global menu - remove the fixed width on .t-navigation .c-sheet__wrapper
- Change the style of pw-sheet_wrapper c-sheet_wrapper from left/right: 20% to 15%
- Apply max-wdith of 340px to pw-sheet_wrapper c-sheet_wrapper (to apply to main navigation drawer, estimate shipping modal and anything else that uses a side drawer)

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- check modals that open from right and left