### PR TITLE
[Integration Manager] Reorganize demandware connector

### DIFF
--- a/web/app/integration-manager/_demandware-connector/app/commands.js
+++ b/web/app/integration-manager/_demandware-connector/app/commands.js
@@ -19,10 +19,7 @@ export const initDemandWareSession = () => {
             // To Do: Add this to the store???
             requestHeaders.Authorization = response.headers.get('Authorization')
             options.headers.Authorization = response.headers.get('Authorization')
-        })
-        .then(() => {
-            makeRequest(`${API_END_POINT_URL}/sessions`, options)
-
+            return makeRequest(`${API_END_POINT_URL}/sessions`, options)
         })
 }
 

--- a/web/app/integration-manager/_demandware-connector/app/commands.js
+++ b/web/app/integration-manager/_demandware-connector/app/commands.js
@@ -1,0 +1,82 @@
+import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
+import {receiveNavigationData} from '../../responses'
+
+import {API_END_POINT_URL, DW_CLIENT_ID, SITE_ID} from '../constants'
+
+export const requestHeaders = {
+    'Content-Type': 'application/json',
+    'x-dw-client-id': DW_CLIENT_ID
+}
+
+export const initDemandWareSession = () => {
+    const options = {
+        method: 'POST',
+        body: '{ type : "session" }',
+        headers: requestHeaders
+    }
+    return makeRequest(`${API_END_POINT_URL}/customers/auth`, options)
+        .then((response) => {
+            // To Do: Add this to the store???
+            requestHeaders.Authorization = response.headers.get('Authorization')
+            options.headers.Authorization = response.headers.get('Authorization')
+        })
+        .then(() => {
+            makeRequest(`${API_END_POINT_URL}/sessions`, options)
+
+        })
+}
+
+export const fetchNavigationData = () => (dispatch) => {
+    const options = {
+        method: 'GET',
+        headers: requestHeaders
+    }
+    return makeRequest(`${API_END_POINT_URL}/categories/root?levels=2`, options)
+        .then((response) => response.json())
+        .then(({categories}) => {
+            const navData = categories.map((category) => {
+                return {
+                    title: category.name,
+                    path: `/s/${SITE_ID}/${category.id}`,
+                    isCategoryLink: true
+                }
+            })
+            return dispatch(receiveNavigationData({
+                path: '/',
+                root: {
+                    title: 'root',
+                    path: '/',
+                    children: [
+                        {
+                            // TODO: Find a way to get this data without hardcoding
+                            title: 'Sign In',
+                            path: `/on/demandware.store/${SITE_ID}/default/Account-Show`,
+                            type: 'AccountNavItem'
+                        },
+                        ...navData
+                    ]
+                }
+            }))
+        })
+}
+
+export const getBasketID = () => {
+    const basketMatch = /mob-basket=([^;]+);/.exec(document.cookie)
+    if (basketMatch) {
+        return new Promise((resolve) => {
+            resolve(basketMatch[1])
+        })
+    }
+    const options = {
+        method: 'POST',
+        headers: requestHeaders
+    }
+    return makeRequest(`${API_END_POINT_URL}/baskets`, options)
+        .then((response) => response.json())
+        .then((responseJSON) => {
+            const basketID = responseJSON.basket_id
+
+            document.cookie = `mob-basket=${basketID}`
+            return basketID
+        })
+}

--- a/web/app/integration-manager/_demandware-connector/commands.js
+++ b/web/app/integration-manager/_demandware-connector/commands.js
@@ -1,141 +1,15 @@
 import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
-import {urlToPathKey} from '../../utils/utils'
 import {receiveCartContents} from '../../store/cart/actions'
-import {receiveHomeData, receiveNavigationData} from '../responses'
-import {receiveProductDetailsProductData, receiveProductDetailsUIData} from '../product-details/responses'
-import {parseProductDetails, parseBasketContents} from './parser'
+import {parseBasketContents, getCurrentProductID} from './parser'
 
-const SITE_ID = 'Sites-2017refresh-Site'
-const API_TYPE = 'shop'
-const API_VERSION = 'v17_2'
-const DW_CLIENT_ID = '5640cc6b-f5e9-466e-9134-9853e9f9db93'
-const API_END_POINT_URL = `/s/${SITE_ID}/dw/${API_TYPE}/${API_VERSION}`
-const requestHeaders = {
-    'Content-Type': 'application/json',
-    'x-dw-client-id': DW_CLIENT_ID
-}
+import {API_END_POINT_URL} from './constants'
+import {requestHeaders, initDemandWareSession, getBasketID} from './app/commands'
 
-const initDemandWareSession = () => {
-    const options = {
-        method: 'POST',
-        body: '{ type : "session" }',
-        headers: requestHeaders
-    }
-    return makeRequest(`${API_END_POINT_URL}/customers/auth`, options)
-        .then((response) => {
-            // To Do: Add this to the store???
-            requestHeaders.Authorization = response.headers.get('Authorization')
-            options.headers.Authorization = response.headers.get('Authorization')
-        })
-        .then(() => {
-            makeRequest(`${API_END_POINT_URL}/sessions`, options)
-
-        })
-}
-
-const getBasketID = () => {
-    const basketMatch = /mob-basket=([^;]+);/.exec(document.cookie)
-    if (basketMatch) {
-        return new Promise((resolve) => {
-            resolve(basketMatch[1])
-        })
-    }
-    const options = {
-        method: 'POST',
-        headers: requestHeaders
-    }
-    return makeRequest(`${API_END_POINT_URL}/baskets`, options)
-        .then((response) => response.json())
-        .then((responseJSON) => {
-            const basketID = responseJSON.basket_id
-
-            document.cookie = `mob-basket=${basketID}`
-            return basketID
-        })
-}
-
-const getCurrentProductID = () => {
-    const productIDMatch = /(\d+).html/.exec(window.location.href)
-    return productIDMatch ? productIDMatch[1] : ''
-}
-
-const fetchNavigationData = () => (dispatch) => {
-    const options = {
-        method: 'GET',
-        headers: requestHeaders
-    }
-    return makeRequest(`${API_END_POINT_URL}/categories/root?levels=2`, options)
-        .then((response) => response.json())
-        .then(({categories}) => {
-            const navData = categories.map((category) => {
-                return {
-                    title: category.name,
-                    path: `/s/${SITE_ID}/${category.id}`,
-                    isCategoryLink: true
-                }
-            })
-            return dispatch(receiveNavigationData({
-                path: '/',
-                root: {
-                    title: 'root',
-                    path: '/',
-                    children: [
-                        {
-                            // TODO: Find a way to get this data without hardcoding
-                            title: 'Sign In',
-                            path: `/on/demandware.store/${SITE_ID}/default/Account-Show`,
-                            type: 'AccountNavItem'
-                        },
-                        ...navData
-                    ]
-                }
-            }))
-        })
-}
-
-export const fetchHomeData = () => (dispatch) => {
-    return initDemandWareSession()
-        .then(() => dispatch(fetchNavigationData()))
-        .then(() => {
-            // Banners are being pulled from the bundle right now
-            // so we just need an array with the correct number of objects
-            dispatch(receiveHomeData({banners: [{}, {}, {}]}))
-        })
-}
-
-export const fetchPdpData = () => (dispatch) => {
-    const productURL = `${API_END_POINT_URL}/products/${getCurrentProductID()}?expand=prices,images`
-    const productPathKey = urlToPathKey(window.location.href)
-    return initDemandWareSession()
-        .then(() => {
-            const options = {
-                method: 'GET',
-                headers: requestHeaders
-            }
-            return makeRequest(productURL, options)
-                .then((response) => response.json())
-                .then((responseJSON) => {
-                    dispatch(receiveProductDetailsProductData({[productPathKey]: parseProductDetails(responseJSON)}))
-                    dispatch(receiveProductDetailsUIData({[productPathKey]: {itemQuantity: responseJSON.step_quantity, ctaText: 'Add To Cart'}}))
-                })
-        })
-        .then(getBasketID)
-        .then((basketID) => {
-            const options = {
-                method: 'GET',
-                headers: requestHeaders
-            }
-            return makeRequest(`${API_END_POINT_URL}/baskets/${basketID}`, options)
-                .then((response) => response.json())
-                .then((responseJSON) => {
-                    dispatch(receiveCartContents(parseBasketContents(responseJSON)))
-                })
-        })
-
-}
+import * as homeCommands from './home/commands'
+import * as productDetailsCommands from './product-details/commands'
 
 
-export const addToCart = () => (dispatch) => {
+const addToCart = () => (dispatch) => {
     return initDemandWareSession()
         .then(getBasketID)
         .then((basketID) => {
@@ -158,18 +32,31 @@ export const addToCart = () => (dispatch) => {
         })
 }
 
-export const fetchCheckoutShippingData = () => {
+const fetchCheckoutShippingData = () => {
     console.log('Fetch checkout shipping data')
 }
 
-export const submitShipping = () => {
+const submitShipping = () => {
     console.log('submit shipping form')
 }
 
-export const checkCustomerEmail = () => {
+const checkCustomerEmail = () => {
     console.log('Check customer email')
 }
 
-export const submitSignIn = () => {
+const submitSignIn = () => {
     console.log('Submit sign in form')
+}
+
+export default {
+    // These individual commands are temporary until we can refactor them into the
+    // sub-areas they belong in.
+    fetchCheckoutShippingData,
+    addToCart,
+    submitShipping,
+    checkCustomerEmail,
+    submitSignIn,
+
+    home: homeCommands,
+    productDetails: productDetailsCommands
 }

--- a/web/app/integration-manager/_demandware-connector/constants.js
+++ b/web/app/integration-manager/_demandware-connector/constants.js
@@ -1,0 +1,5 @@
+const API_TYPE = 'shop'
+const API_VERSION = 'v17_2'
+export const SITE_ID = 'Sites-2017refresh-Site'
+export const DW_CLIENT_ID = '5640cc6b-f5e9-466e-9134-9853e9f9db93'
+export const API_END_POINT_URL = `/s/${SITE_ID}/dw/${API_TYPE}/${API_VERSION}`

--- a/web/app/integration-manager/_demandware-connector/home/commands.js
+++ b/web/app/integration-manager/_demandware-connector/home/commands.js
@@ -1,0 +1,12 @@
+import {receiveHomeData} from '../../responses'
+import {initDemandWareSession, fetchNavigationData} from '../app/commands'
+
+export const fetchHomeData = () => (dispatch) => {
+    return initDemandWareSession()
+        .then(() => dispatch(fetchNavigationData()))
+        .then(() => {
+            // Banners are being pulled from the bundle right now
+            // so we just need an array with the correct number of objects
+            dispatch(receiveHomeData({banners: [{}, {}, {}]}))
+        })
+}

--- a/web/app/integration-manager/_demandware-connector/index.js
+++ b/web/app/integration-manager/_demandware-connector/index.js
@@ -1,4 +1,4 @@
-import * as commands from './commands'
+import commands from './commands'
 import reducer from './reducer'
 
 const connector = {commands, reducer}

--- a/web/app/integration-manager/_demandware-connector/parser.js
+++ b/web/app/integration-manager/_demandware-connector/parser.js
@@ -13,6 +13,11 @@ export const parseProductDetails = ({name, price, long_description, image_groups
     }
 }
 
+export const getCurrentProductID = () => {
+    const productIDMatch = /(\d+).html/.exec(window.location.href)
+    return productIDMatch ? productIDMatch[1] : ''
+}
+
 
 export const parseBasketContents = ({product_items, product_sub_total}) => {
     const items = product_items.map(({product_name, base_price, quantity}) => {

--- a/web/app/integration-manager/_demandware-connector/product-details/commands.js
+++ b/web/app/integration-manager/_demandware-connector/product-details/commands.js
@@ -1,0 +1,38 @@
+import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
+import {receiveProductDetailsProductData, receiveProductDetailsUIData} from '../../product-details/responses'
+import {receiveCartContents} from '../../../store/cart/actions'
+import {urlToPathKey} from '../../../utils/utils'
+import {requestHeaders, initDemandWareSession, getBasketID} from '../app/commands'
+import {parseProductDetails, getCurrentProductID, parseBasketContents} from '../parser'
+import {API_END_POINT_URL} from '../constants'
+
+export const fetchPdpData = () => (dispatch) => {
+    const productURL = `${API_END_POINT_URL}/products/${getCurrentProductID()}?expand=prices,images`
+    const productPathKey = urlToPathKey(window.location.href)
+    return initDemandWareSession()
+        .then(() => {
+            const options = {
+                method: 'GET',
+                headers: requestHeaders
+            }
+            return makeRequest(productURL, options)
+                .then((response) => response.json())
+                .then((responseJSON) => {
+                    dispatch(receiveProductDetailsProductData({[productPathKey]: parseProductDetails(responseJSON)}))
+                    dispatch(receiveProductDetailsUIData({[productPathKey]: {itemQuantity: responseJSON.step_quantity, ctaText: 'Add To Cart'}}))
+                })
+        })
+        .then(getBasketID)
+        .then((basketID) => {
+            const options = {
+                method: 'GET',
+                headers: requestHeaders
+            }
+            return makeRequest(`${API_END_POINT_URL}/baskets/${basketID}`, options)
+                .then((response) => response.json())
+                .then((responseJSON) => {
+                    dispatch(receiveCartContents(parseBasketContents(responseJSON)))
+                })
+        })
+
+}

--- a/web/app/integration-manager/commands.js
+++ b/web/app/integration-manager/commands.js
@@ -5,7 +5,6 @@ let connector = {}
 
 export const register = (commands) => {
     connector = commands
-
     registerHome(commands.home)
     registerProductDetails(commands.productDetails)
 }

--- a/web/app/main.jsx
+++ b/web/app/main.jsx
@@ -19,8 +19,8 @@ import Stylesheet from './stylesheet.scss' // eslint-disable-line no-unused-vars
 import {analyticManager} from 'progressive-web-sdk/dist/analytics/analytic-manager'
 import {clientAnalytics} from './utils/analytics/client-analytics'
 
-import connector from './integration-manager/_merlins-connector'
-// import connector from './integration-manager/_demandware-connector'
+// import connector from './integration-manager/_merlins-connector'
+import connector from './integration-manager/_demandware-connector'
 
 import {registerConnector} from './integration-manager'
 


### PR DESCRIPTION
This PR updates the demandware connector to match the reorganized merlins connector.

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1256
 **Linked PRs**: #423

## Changes
- Move home and PDP commands for demandware connector into their own folder

## How to test-drive this PR
- Set up tag injector for the demandware sandbox (http://mobify-tech-prtnr-na03-dw.demandware.net/on/demandware.store/Sites-2017refresh-Site/default/Home-Show)
- Run `npm run dev`
- Preview [the demandware site](https://preview.mobify.com/?url=http%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- The homepage should work correctly
