### PR TITLE
[Integration Manager] Demandware navigation fixes

### DIFF
--- a/web/app/containers/navigation/actions.js
+++ b/web/app/containers/navigation/actions.js
@@ -1,6 +1,7 @@
 import {createAction} from '../../utils/utils'
 import {parseNavigation} from './parser'
 
+export const setNavigationPath = createAction('Set Navigation Path', 'path')
 export const receiveData = createAction('Receive navigation data')
 
 export const process = ({payload}) => {

--- a/web/app/containers/navigation/container.js
+++ b/web/app/containers/navigation/container.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {createStructuredSelector} from 'reselect'
 import {selectorToJS} from '../../utils/selector-utils'
+import {extractPathFromURL} from '../../utils/utils'
 
 import Nav from 'progressive-web-sdk/dist/components/nav'
 import NavMenu from 'progressive-web-sdk/dist/components/nav-menu'
@@ -36,13 +37,7 @@ const Navigation = (props) => {
 
     const onPathChange = (path, isLeaf) => {
         if (isLeaf) {
-            let routerPath = path
-            if (!/^\//.test(path)) {
-                const url = new URL(path)
-                // Path in the nav expected to be on this domain. React-router now only accepts
-                // a path, instead of a full url.
-                routerPath = url.pathname + url.search + url.hash
-            }
+            const routerPath = extractPathFromURL(path, true)
             router.push(routerPath)
             setNavigationPath('/')
             closeNavigation()

--- a/web/app/containers/navigation/container.js
+++ b/web/app/containers/navigation/container.js
@@ -13,6 +13,7 @@ import * as selectors from './selectors'
 import {NAVIGATION_MODAL} from './constants'
 import {isModalOpen} from '../../store/selectors'
 import {closeModal} from '../../store/modals/actions'
+import {setNavigationPath} from './actions'
 import {HeaderBar, HeaderBarActions, HeaderBarTitle} from 'progressive-web-sdk/dist/components/header-bar'
 import {withRouter} from 'progressive-web-sdk/dist/routing'
 
@@ -31,15 +32,23 @@ const itemFactory = (type, props) => {
 
 
 const Navigation = (props) => {
-    const {path, isOpen, root, closeNavigation, router} = props
+    const {path, isOpen, root, closeNavigation, router, setNavigationPath} = props
 
-    const onPathChange = (path) => {
-        const url = new URL(path)
-        // Path in the nav expected to be on this domain. React-router now only accepts
-        // a path, instead of a full url.
-        const routerPath = url.pathname + url.search + url.hash
-        router.push(routerPath)
-        closeNavigation()
+    const onPathChange = (path, isLeaf) => {
+        if (isLeaf) {
+            let routerPath = path
+            if (!/^\//.test(path)) {
+                const url = new URL(path)
+                // Path in the nav expected to be on this domain. React-router now only accepts
+                // a path, instead of a full url.
+                routerPath = url.pathname + url.search + url.hash
+            }
+            router.push(routerPath)
+            setNavigationPath('/')
+            closeNavigation()
+        } else {
+            setNavigationPath(path)
+        }
     }
 
     return (
@@ -77,6 +86,10 @@ Navigation.propTypes = {
      * The react-router router object.
      */
     router: PropTypes.object,
+    /**
+    * Sets the current path for the navigation menu
+    */
+    setNavigationPath: PropTypes.func
 }
 
 
@@ -87,7 +100,8 @@ const mapStateToProps = createStructuredSelector({
 })
 
 const mapDispatchToProps = {
-    closeNavigation: () => closeModal(NAVIGATION_MODAL)
+    closeNavigation: () => closeModal(NAVIGATION_MODAL),
+    setNavigationPath,
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(Navigation))

--- a/web/app/containers/navigation/reducer.js
+++ b/web/app/containers/navigation/reducer.js
@@ -2,7 +2,7 @@ import {handleActions} from 'redux-actions'
 import Immutable from 'immutable'
 import {receiveNavigationData} from '../../integration-manager/responses'
 import {mergePayloadForActions} from '../../utils/reducer-utils'
-import {receiveData} from './actions'
+import {receiveData, setNavigationPath} from './actions'
 
 export const initialState = Immutable.fromJS({
     path: undefined,
@@ -11,7 +11,7 @@ export const initialState = Immutable.fromJS({
 
 
 export const reducer = handleActions({
-    ...mergePayloadForActions(receiveNavigationData, receiveData)
+    ...mergePayloadForActions(receiveNavigationData, receiveData, setNavigationPath)
 }, initialState)
 
 

--- a/web/app/integration-manager/_demandware-connector/app/commands.js
+++ b/web/app/integration-manager/_demandware-connector/app/commands.js
@@ -1,5 +1,6 @@
 import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 import {receiveNavigationData} from '../../responses'
+import {parseCategories} from '../parser'
 
 import {API_END_POINT_URL, DW_CLIENT_ID, SITE_ID} from '../constants'
 
@@ -26,6 +27,9 @@ export const initDemandWareSession = () => {
         })
 }
 
+
+
+
 export const fetchNavigationData = () => (dispatch) => {
     const options = {
         method: 'GET',
@@ -34,13 +38,7 @@ export const fetchNavigationData = () => (dispatch) => {
     return makeRequest(`${API_END_POINT_URL}/categories/root?levels=2`, options)
         .then((response) => response.json())
         .then(({categories}) => {
-            const navData = categories.map((category) => {
-                return {
-                    title: category.name,
-                    path: `/s/${SITE_ID}/${category.id}`,
-                    isCategoryLink: true
-                }
-            })
+            const navData = parseCategories(categories)
             return dispatch(receiveNavigationData({
                 path: '/',
                 root: {

--- a/web/app/integration-manager/_demandware-connector/app/commands.js
+++ b/web/app/integration-manager/_demandware-connector/app/commands.js
@@ -1,0 +1,82 @@
+import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
+import {receiveNavigationData} from '../../responses'
+
+import {API_END_POINT_URL, DW_CLIENT_ID, SITE_ID} from '../constants'
+
+export const requestHeaders = {
+    'Content-Type': 'application/json',
+    'x-dw-client-id': DW_CLIENT_ID
+}
+
+export const initDemandWareSession = () => {
+    const options = {
+        method: 'POST',
+        body: '{ type : "session" }',
+        headers: requestHeaders
+    }
+    return makeRequest(`${API_END_POINT_URL}/customers/auth`, options)
+        .then((response) => {
+            // To Do: Add this to the store???
+            requestHeaders.Authorization = response.headers.get('Authorization')
+            options.headers.Authorization = response.headers.get('Authorization')
+        })
+        .then(() => {
+            makeRequest(`${API_END_POINT_URL}/sessions`, options)
+
+        })
+}
+
+export const fetchNavigationData = () => (dispatch) => {
+    const options = {
+        method: 'GET',
+        headers: requestHeaders
+    }
+    return makeRequest(`${API_END_POINT_URL}/categories/root?levels=2`, options)
+        .then((response) => response.json())
+        .then(({categories}) => {
+            const navData = categories.map((category) => {
+                return {
+                    title: category.name,
+                    path: `/s/${SITE_ID}/${category.id}`,
+                    isCategoryLink: true
+                }
+            })
+            return dispatch(receiveNavigationData({
+                path: '/',
+                root: {
+                    title: 'root',
+                    path: '/',
+                    children: [
+                        {
+                            // TODO: Find a way to get this data without hardcoding
+                            title: 'Sign In',
+                            path: `/on/demandware.store/${SITE_ID}/default/Account-Show`,
+                            type: 'AccountNavItem'
+                        },
+                        ...navData
+                    ]
+                }
+            }))
+        })
+}
+
+export const getBasketID = () => {
+    const basketMatch = /mob-basket=([^;]+);/.exec(document.cookie)
+    if (basketMatch) {
+        return new Promise((resolve) => {
+            resolve(basketMatch[1])
+        })
+    }
+    const options = {
+        method: 'POST',
+        headers: requestHeaders
+    }
+    return makeRequest(`${API_END_POINT_URL}/baskets`, options)
+        .then((response) => response.json())
+        .then((responseJSON) => {
+            const basketID = responseJSON.basket_id
+
+            document.cookie = `mob-basket=${basketID}`
+            return basketID
+        })
+}

--- a/web/app/integration-manager/_demandware-connector/app/commands.js
+++ b/web/app/integration-manager/_demandware-connector/app/commands.js
@@ -1,6 +1,6 @@
 import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 import {receiveNavigationData} from '../../responses'
-import {parseCategories} from '../parser'
+import {parseCategories} from '../parsers'
 
 import {API_END_POINT_URL, DW_CLIENT_ID, SITE_ID} from '../constants'
 

--- a/web/app/integration-manager/_demandware-connector/commands.js
+++ b/web/app/integration-manager/_demandware-connector/commands.js
@@ -1,141 +1,15 @@
 import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
-import {urlToPathKey} from '../../utils/utils'
 import {receiveCartContents} from '../../store/cart/actions'
-import {receiveHomeData, receiveNavigationData} from '../responses'
-import {receiveProductDetailsProductData, receiveProductDetailsUIData} from '../product-details/responses'
-import {parseProductDetails, parseBasketContents} from './parser'
+import {parseBasketContents, getCurrentProductID} from './parser'
 
-const SITE_ID = 'Sites-2017refresh-Site'
-const API_TYPE = 'shop'
-const API_VERSION = 'v17_2'
-const DW_CLIENT_ID = '5640cc6b-f5e9-466e-9134-9853e9f9db93'
-const API_END_POINT_URL = `/s/${SITE_ID}/dw/${API_TYPE}/${API_VERSION}`
-const requestHeaders = {
-    'Content-Type': 'application/json',
-    'x-dw-client-id': DW_CLIENT_ID
-}
+import {API_END_POINT_URL} from './constants'
+import {requestHeaders, initDemandWareSession, getBasketID} from './app/commands'
 
-const initDemandWareSession = () => {
-    const options = {
-        method: 'POST',
-        body: '{ type : "session" }',
-        headers: requestHeaders
-    }
-    return makeRequest(`${API_END_POINT_URL}/customers/auth`, options)
-        .then((response) => {
-            // To Do: Add this to the store???
-            requestHeaders.Authorization = response.headers.get('Authorization')
-            options.headers.Authorization = response.headers.get('Authorization')
-        })
-        .then(() => {
-            makeRequest(`${API_END_POINT_URL}/sessions`, options)
-
-        })
-}
-
-const getBasketID = () => {
-    const basketMatch = /mob-basket=([^;]+);/.exec(document.cookie)
-    if (basketMatch) {
-        return new Promise((resolve) => {
-            resolve(basketMatch[1])
-        })
-    }
-    const options = {
-        method: 'POST',
-        headers: requestHeaders
-    }
-    return makeRequest(`${API_END_POINT_URL}/baskets`, options)
-        .then((response) => response.json())
-        .then((responseJSON) => {
-            const basketID = responseJSON.basket_id
-
-            document.cookie = `mob-basket=${basketID}`
-            return basketID
-        })
-}
-
-const getCurrentProductID = () => {
-    const productIDMatch = /(\d+).html/.exec(window.location.href)
-    return productIDMatch ? productIDMatch[1] : ''
-}
-
-const fetchNavigationData = () => (dispatch) => {
-    const options = {
-        method: 'GET',
-        headers: requestHeaders
-    }
-    return makeRequest(`${API_END_POINT_URL}/categories/root?levels=2`, options)
-        .then((response) => response.json())
-        .then(({categories}) => {
-            const navData = categories.map((category) => {
-                return {
-                    title: category.name,
-                    path: `/s/${SITE_ID}/${category.id}`,
-                    isCategoryLink: true
-                }
-            })
-            return dispatch(receiveNavigationData({
-                path: '/',
-                root: {
-                    title: 'root',
-                    path: '/',
-                    children: [
-                        {
-                            // TODO: Find a way to get this data without hardcoding
-                            title: 'Sign In',
-                            path: `/on/demandware.store/${SITE_ID}/default/Account-Show`,
-                            type: 'AccountNavItem'
-                        },
-                        ...navData
-                    ]
-                }
-            }))
-        })
-}
-
-export const fetchHomeData = () => (dispatch) => {
-    return initDemandWareSession()
-        .then(() => dispatch(fetchNavigationData()))
-        .then(() => {
-            // Banners are being pulled from the bundle right now
-            // so we just need an array with the correct number of objects
-            dispatch(receiveHomeData({banners: [{}, {}, {}]}))
-        })
-}
-
-export const fetchPdpData = () => (dispatch) => {
-    const productURL = `${API_END_POINT_URL}/products/${getCurrentProductID()}?expand=prices,images`
-    const productPathKey = urlToPathKey(window.location.href)
-    return initDemandWareSession()
-        .then(() => {
-            const options = {
-                method: 'GET',
-                headers: requestHeaders
-            }
-            return makeRequest(productURL, options)
-                .then((response) => response.json())
-                .then((responseJSON) => {
-                    dispatch(receiveProductDetailsProductData({[productPathKey]: parseProductDetails(responseJSON)}))
-                    dispatch(receiveProductDetailsUIData({[productPathKey]: {itemQuantity: responseJSON.step_quantity, ctaText: 'Add To Cart'}}))
-                })
-        })
-        .then(getBasketID)
-        .then((basketID) => {
-            const options = {
-                method: 'GET',
-                headers: requestHeaders
-            }
-            return makeRequest(`${API_END_POINT_URL}/baskets/${basketID}`, options)
-                .then((response) => response.json())
-                .then((responseJSON) => {
-                    dispatch(receiveCartContents(parseBasketContents(responseJSON)))
-                })
-        })
-
-}
+import * as homeCommands from './home/commands'
+import * as productDetailsCommands from './product-details/commands'
 
 
-export const addToCart = () => (dispatch) => {
+const addToCart = () => (dispatch) => {
     return initDemandWareSession()
         .then(getBasketID)
         .then((basketID) => {
@@ -158,18 +32,31 @@ export const addToCart = () => (dispatch) => {
         })
 }
 
-export const fetchCheckoutShippingData = () => {
+const fetchCheckoutShippingData = () => {
     console.log('Fetch checkout shipping data')
 }
 
-export const submitShipping = () => {
+const submitShipping = () => {
     console.log('submit shipping form')
 }
 
-export const checkCustomerEmail = () => {
+const checkCustomerEmail = () => {
     console.log('Check customer email')
 }
 
-export const submitSignIn = () => {
+const submitSignIn = () => {
     console.log('Submit sign in form')
+}
+
+export default {
+    // These individual commands are temporary until we can refactor them into the
+    // sub-areas they belong in.
+    fetchCheckoutShippingData,
+    addToCart,
+    submitShipping,
+    checkCustomerEmail,
+    submitSignIn,
+
+    home: homeCommands,
+    productDetails: productDetailsCommands
 }

--- a/web/app/integration-manager/_demandware-connector/commands.js
+++ b/web/app/integration-manager/_demandware-connector/commands.js
@@ -1,6 +1,6 @@
 import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 import {receiveCartContents} from '../../store/cart/actions'
-import {parseBasketContents, getCurrentProductID} from './parser'
+import {parseBasketContents, getCurrentProductID} from './parsers'
 
 import {API_END_POINT_URL} from './constants'
 import {requestHeaders, initDemandWareSession, getBasketID} from './app/commands'

--- a/web/app/integration-manager/_demandware-connector/constants.js
+++ b/web/app/integration-manager/_demandware-connector/constants.js
@@ -1,0 +1,5 @@
+const API_TYPE = 'shop'
+const API_VERSION = 'v17_2'
+export const SITE_ID = 'Sites-2017refresh-Site'
+export const DW_CLIENT_ID = '5640cc6b-f5e9-466e-9134-9853e9f9db93'
+export const API_END_POINT_URL = `/s/${SITE_ID}/dw/${API_TYPE}/${API_VERSION}`

--- a/web/app/integration-manager/_demandware-connector/home/commands.js
+++ b/web/app/integration-manager/_demandware-connector/home/commands.js
@@ -1,0 +1,12 @@
+import {receiveHomeData} from '../../responses'
+import {initDemandWareSession, fetchNavigationData} from '../app/commands'
+
+export const fetchHomeData = () => (dispatch) => {
+    return initDemandWareSession()
+        .then(() => dispatch(fetchNavigationData()))
+        .then(() => {
+            // Banners are being pulled from the bundle right now
+            // so we just need an array with the correct number of objects
+            dispatch(receiveHomeData({banners: [{}, {}, {}]}))
+        })
+}

--- a/web/app/integration-manager/_demandware-connector/index.js
+++ b/web/app/integration-manager/_demandware-connector/index.js
@@ -1,4 +1,4 @@
-import * as commands from './commands'
+import commands from './commands'
 import reducer from './reducer'
 
 const connector = {commands, reducer}

--- a/web/app/integration-manager/_demandware-connector/parser.js
+++ b/web/app/integration-manager/_demandware-connector/parser.js
@@ -13,6 +13,11 @@ export const parseProductDetails = ({name, price, long_description, image_groups
     }
 }
 
+export const getCurrentProductID = () => {
+    const productIDMatch = /(\d+).html/.exec(window.location.href)
+    return productIDMatch ? productIDMatch[1] : ''
+}
+
 
 export const parseBasketContents = ({product_items, product_sub_total}) => {
     const items = product_items.map(({product_name, base_price, quantity}) => {

--- a/web/app/integration-manager/_demandware-connector/parsers.js
+++ b/web/app/integration-manager/_demandware-connector/parsers.js
@@ -1,3 +1,6 @@
+
+import {SITE_ID} from '../constants'
+
 const parseCarouselItems = (imageGroups) => {
     const largeImages = imageGroups.filter((imageGroup) => imageGroup.view_type === 'large')[0]
     return largeImages.images.map(({alt, link}, idx) => ({alt, img: link, position: idx.toString()}))
@@ -33,4 +36,15 @@ export const parseBasketContents = ({product_items, product_sub_total}) => {
         subtotal: `$${product_sub_total.toFixed(2).toString()}`,
         summary_count: items && items.length
     }
+}
+
+export const parseCategories = (categories) => {
+    return categories.map((category) => {
+        return {
+            title: category.name,
+            path: `/s/${SITE_ID}/${category.id}`,
+            isCategoryLink: true,
+            children: category.categories ? parseCategories(category.categories) : []
+        }
+    })
 }

--- a/web/app/integration-manager/_demandware-connector/parsers.js
+++ b/web/app/integration-manager/_demandware-connector/parsers.js
@@ -1,5 +1,5 @@
 
-import {SITE_ID} from '../constants'
+import {SITE_ID} from './constants'
 
 const parseCarouselItems = (imageGroups) => {
     const largeImages = imageGroups.filter((imageGroup) => imageGroup.view_type === 'large')[0]

--- a/web/app/integration-manager/_demandware-connector/product-details/commands.js
+++ b/web/app/integration-manager/_demandware-connector/product-details/commands.js
@@ -3,7 +3,7 @@ import {receiveProductDetailsProductData, receiveProductDetailsUIData} from '../
 import {receiveCartContents} from '../../../store/cart/actions'
 import {urlToPathKey} from '../../../utils/utils'
 import {requestHeaders, initDemandWareSession, getBasketID} from '../app/commands'
-import {parseProductDetails, getCurrentProductID, parseBasketContents} from '../parser'
+import {parseProductDetails, getCurrentProductID, parseBasketContents} from '../parsers'
 import {API_END_POINT_URL} from '../constants'
 
 export const fetchPdpData = () => (dispatch) => {

--- a/web/app/integration-manager/_demandware-connector/product-details/commands.js
+++ b/web/app/integration-manager/_demandware-connector/product-details/commands.js
@@ -1,0 +1,38 @@
+import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
+import {receiveProductDetailsProductData, receiveProductDetailsUIData} from '../../product-details/responses'
+import {receiveCartContents} from '../../../store/cart/actions'
+import {urlToPathKey} from '../../../utils/utils'
+import {requestHeaders, initDemandWareSession, getBasketID} from '../app/commands'
+import {parseProductDetails, getCurrentProductID, parseBasketContents} from '../parser'
+import {API_END_POINT_URL} from '../constants'
+
+export const fetchPdpData = () => (dispatch) => {
+    const productURL = `${API_END_POINT_URL}/products/${getCurrentProductID()}?expand=prices,images`
+    const productPathKey = urlToPathKey(window.location.href)
+    return initDemandWareSession()
+        .then(() => {
+            const options = {
+                method: 'GET',
+                headers: requestHeaders
+            }
+            return makeRequest(productURL, options)
+                .then((response) => response.json())
+                .then((responseJSON) => {
+                    dispatch(receiveProductDetailsProductData({[productPathKey]: parseProductDetails(responseJSON)}))
+                    dispatch(receiveProductDetailsUIData({[productPathKey]: {itemQuantity: responseJSON.step_quantity, ctaText: 'Add To Cart'}}))
+                })
+        })
+        .then(getBasketID)
+        .then((basketID) => {
+            const options = {
+                method: 'GET',
+                headers: requestHeaders
+            }
+            return makeRequest(`${API_END_POINT_URL}/baskets/${basketID}`, options)
+                .then((response) => response.json())
+                .then((responseJSON) => {
+                    dispatch(receiveCartContents(parseBasketContents(responseJSON)))
+                })
+        })
+
+}

--- a/web/app/integration-manager/commands.js
+++ b/web/app/integration-manager/commands.js
@@ -5,7 +5,6 @@ let connector = {}
 
 export const register = (commands) => {
     connector = commands
-
     registerHome(commands.home)
     registerProductDetails(commands.productDetails)
 }

--- a/web/app/main.jsx
+++ b/web/app/main.jsx
@@ -19,8 +19,8 @@ import Stylesheet from './stylesheet.scss' // eslint-disable-line no-unused-vars
 import {analyticManager} from 'progressive-web-sdk/dist/analytics/analytic-manager'
 import {clientAnalytics} from './utils/analytics/client-analytics'
 
-import connector from './integration-manager/_merlins-connector'
-// import connector from './integration-manager/_demandware-connector'
+// import connector from './integration-manager/_merlins-connector'
+import connector from './integration-manager/_demandware-connector'
 
 import {registerConnector} from './integration-manager'
 

--- a/web/app/utils/utils.js
+++ b/web/app/utils/utils.js
@@ -89,18 +89,25 @@ export const stripEvent = (fn) => () => fn()
 
 
 /**
- * Converts a full URL to the preferred format for keying the redux store,
- * i.e. the path and query string
- */
-export const urlToPathKey = (url) => {
+* Converts a URL to the relative URL
+* @param {string} url - the url to be converted (if it's already relative it will be returned as is)
+* @param {bool} includeHash - indicates if the URL hash should be included in the relative URL returns
+*/
+export const extractPathFromURL = (url, includeHash) => {
     if (/^\//.test(url)) {
         // The URL is already relative, so just return it
         return url
     }
     const urlObject = new URL(url)
 
-    return `${urlObject.pathname}${urlObject.search}`
+    return `${urlObject.pathname}${urlObject.search}${includeHash ? url.hash : ''}`
 }
+
+/**
+ * Converts a full URL to the preferred format for keying the redux store,
+ * i.e. the path and query string
+ */
+export const urlToPathKey = (url) => extractPathFromURL(url, false)
 
 /**
  * Returns a path given a `location` object.


### PR DESCRIPTION
This PR updates the site navigation to work with child categories, and fixes the demandware navigation parsing to return the correct structure for the NavMenu component. 

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1256
 **Linked PRs**: n/a

## Changes
- Fixed demandware navigation parser to return correct structure
- Added action/reducer to show navigation panels correctly.

## How to test-drive this PR
- Set up tag injector for the demandware sandbox (http://mobify-tech-prtnr-na03-dw.demandware.net/on/demandware.store/Sites-2017refresh-Site/default/Home-Show)
- Run `npm run dev`
- Preview [the demandware site](https://preview.mobify.com/?url=http%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Open the site menu and try using the navigation
- You will only see a URL change when you reach a leaf in the navigation since PLP routes are being added in another PR
