### PR TITLE
add animation to 'add new card' section

### DIFF
--- a/web/app/containers/checkout-payment/_checkout-payment.scss
+++ b/web/app/containers/checkout-payment/_checkout-payment.scss
@@ -44,6 +44,7 @@
 
 .t-checkout-payment__add-new-card-form {
     opacity: 0;
+
     animation: fadeIn 0.2s 0.2s ease-out 1 forwards;
 }
 

--- a/web/app/containers/checkout-payment/_checkout-payment.scss
+++ b/web/app/containers/checkout-payment/_checkout-payment.scss
@@ -38,6 +38,15 @@
     }
 }
 
+.t-checkout-payment__add-new-card {
+    transition: padding 0.2s ease-out;
+}
+
+.t-checkout-payment__add-new-card-form {
+    opacity: 0;
+    animation: fadeIn 0.2s 0.2s ease-out 1 forwards;
+}
+
 
 // Fixed Place Order
 // ---

--- a/web/app/containers/checkout-payment/partials/credit-card-form.jsx
+++ b/web/app/containers/checkout-payment/partials/credit-card-form.jsx
@@ -118,7 +118,7 @@ class CreditCardForm extends React.Component {
                             </ReduxForm.Field>
                         </FieldRow>
 
-                        <div className={isNewCardInputSelected ? 'u-padding-md u-margin-top-md u-border-light' : 'u-margin-top-md'}>
+                        <div className={isNewCardInputSelected ? 'u-padding-md u-margin-top-md u-border-light t-checkout-payment__add-new-card' : 'u-margin-top-md t-checkout-payment__add-new-card'}>
                             <FieldRow>
                                 <ReduxForm.Field
                                     component={Field}
@@ -130,7 +130,7 @@ class CreditCardForm extends React.Component {
                             </FieldRow>
 
                             {isNewCardInputSelected &&
-                                <div className="u-margin-top-lg u-padding-top">
+                                <div className="u-margin-top-lg u-padding-top t-checkout-payment__add-new-card-form">
                                     {creditCardForm}
                                 </div>
                             }

--- a/web/app/containers/checkout-payment/partials/credit-card-form.jsx
+++ b/web/app/containers/checkout-payment/partials/credit-card-form.jsx
@@ -3,6 +3,7 @@ import * as ReduxForm from 'redux-form'
 import {connect} from 'react-redux'
 import {createStructuredSelector} from 'reselect'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
+import classNames from 'classnames'
 import {PAYMENT_EXISTING_CARD, PAYMENT_NEW_CARD, AMEX_CARD, DEFAULT_CARD, NUMBER_FIELD} from '../constants'
 
 // Selectors
@@ -118,7 +119,7 @@ class CreditCardForm extends React.Component {
                             </ReduxForm.Field>
                         </FieldRow>
 
-                        <div className={isNewCardInputSelected ? 'u-padding-md u-margin-top-md u-border-light t-checkout-payment__add-new-card' : 'u-margin-top-md t-checkout-payment__add-new-card'}>
+                        <div className={classNames('u-margin-top-md t-checkout-payment__add-new-card', {'u-padding-md u-border-light': isNewCardInputSelected})}>
                             <FieldRow>
                                 <ReduxForm.Field
                                     component={Field}

--- a/web/app/styles/_animations.scss
+++ b/web/app/styles/_animations.scss
@@ -24,6 +24,7 @@
     0% {
         opacity: 0;
     }
+
     100% {
         opacity: 1;
     }

--- a/web/app/styles/_animations.scss
+++ b/web/app/styles/_animations.scss
@@ -19,3 +19,12 @@
         transform: scale(0);
     }
 }
+
+@keyframes fadeIn {
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
Animate ‘add a new card radio’ to new position

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1245

## Changes
- transition padding on add new card
- animate add new card form

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Add an item to cart and checkout 
- on payment step switch between add new card and saved card
