### PR TITLE
Fix PDP reorganization fixes

### DIFF
--- a/web/app/integration-manager/_demandware-connector/commands.js
+++ b/web/app/integration-manager/_demandware-connector/commands.js
@@ -58,5 +58,5 @@ export default {
     submitSignIn,
 
     home: homeCommands,
-    productDetails: productDetailsCommands
+    products: productDetailsCommands
 }

--- a/web/app/integration-manager/_demandware-connector/product-details/commands.js
+++ b/web/app/integration-manager/_demandware-connector/product-details/commands.js
@@ -1,5 +1,5 @@
 import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
-import {receiveProductDetailsProductData, receiveProductDetailsUIData} from '../../product-details/responses'
+import {receiveProductDetailsProductData, receiveProductDetailsUIData} from '../../products/responses'
 import {receiveCartContents} from '../../../store/cart/actions'
 import {urlToPathKey} from '../../../utils/utils'
 import {requestHeaders, initDemandWareSession, getBasketID} from '../app/commands'


### PR DESCRIPTION
This PR fixes a couple errors introduced from the demandware IM reorg work. 

 **JIRA**: n/a
 **Linked PRs**: n/a

## Changes
- Fix import path for DW product responses
- Fix export structure for DW commands 

## How to test-drive this PR
- Set up tag injector for the demandware sandbox (http://mobify-tech-prtnr-na03-dw.demandware.net/on/demandware.store/Sites-2017refresh-Site/default/Home-Show)
- Run `npm run dev`
- Preview [the demandware site](https://preview.mobify.com/?url=http%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Confirm the home page and a PDP still work as expected 


## Notes
- PDPs for "master" products will not be able to be added to the cart, this issue is addressed in another PR)
