### PR TITLE
Add Units to Image Width Prop

### DIFF
--- a/web/app/containers/footer/partials/footer-social-icons.jsx
+++ b/web/app/containers/footer/partials/footer-social-icons.jsx
@@ -23,8 +23,8 @@ const FooterSocialIcons = () => {
                             <Image
                                 src={getAssetUrl(icon)}
                                 alt={title}
-                                height="32"
-                                width="32"
+                                height="32px"
+                                width="32px"
                             />
                         </LazyLoadContent>
                     </a>

--- a/web/app/containers/home/partials/home-categories.jsx
+++ b/web/app/containers/home/partials/home-categories.jsx
@@ -13,7 +13,7 @@ import LazyLoadContent from '../../../components/lazy-load-content'
 import * as selectors from '../selectors'
 
 const CategoryImage = ({alt}) => {
-    const placeholder = <SkeletonBlock height="60" width="60" />
+    const placeholder = <SkeletonBlock height="60px" width="60px" />
 
     if (!alt) {
         return placeholder
@@ -25,8 +25,8 @@ const CategoryImage = ({alt}) => {
                 src={getAssetUrl(`static/img/categories/${alt.trim().replace(/\s+/g, '-')
                         .toLowerCase()}@2x.png`)}
                 alt={alt}
-                height="60"
-                width="60"
+                height="60px"
+                width="60px"
             />
         </LazyLoadContent>
     )


### PR DESCRIPTION
## Changes
- Add unit `px` to image prop values to prevent errors from appear, for example like...
    ![screen_shot_2017-03-16_at_8 39 44_am](https://cloud.githubusercontent.com/assets/734535/24019661/1e71a162-0a56-11e7-8bd7-7032b07c0439.png)

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Scroll to the bottom of the page to trigger any lazy loaded images (including footer icons!)
- Navigate to the PLP and PDP pages
- Verify that the above images no longer appear in console
