### PR TITLE
Remove favicons

### DIFF
--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -91,22 +91,6 @@ if (isReactRoute()) {
      : {then: (fn) => setTimeout(fn)}
     ).then(() => {
         loadAsset('link', {
-            href: getAssetUrl('static/img/global/favicon.png'),
-            rel: 'icon'
-        })
-
-        loadAsset('link', {
-            href: getAssetUrl('static/img/global/favicon.png'),
-            rel: 'apple-touch-icon'
-        })
-
-        loadAsset('link', {
-            href: getAssetUrl('static/img/global/favicon@2x.png'),
-            rel: 'apple-touch-icon',
-            sizes: '96x96'
-        })
-
-        loadAsset('link', {
             href: getAssetUrl('main.css'),
             rel: 'stylesheet',
             type: 'text/css',


### PR DESCRIPTION
## Changes
- Remove Favicons

## Impact

We noticed that all three of the favicons are downloaded onto the device. We originally expected only one to download. Additionally, having our favicons didn't prevent the desktop favicon from being downloaded.

![screen shot 2017-03-16 at 2 46 16 pm](https://cloud.githubusercontent.com/assets/734535/24020026/c426b45c-0a57-11e7-8452-60c295f06098.png)

To save on bandwidth (even if a bit), we're removing the three favicons.

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Verify in Chrome Inspector that only the original desktop favicon is downloaded, but none of the three CDN hosted favicons.
