### PR TITLE
Fix `extractPathFromUrl` helper method

### DIFF
--- a/web/app/utils/utils.js
+++ b/web/app/utils/utils.js
@@ -100,7 +100,7 @@ export const extractPathFromURL = (url, includeHash) => {
     }
     const urlObject = new URL(url)
 
-    return `${urlObject.pathname}${urlObject.search}${includeHash ? url.hash : ''}`
+    return `${urlObject.pathname}${urlObject.search}${includeHash ? urlObject.hash : ''}`
 }
 
 /**


### PR DESCRIPTION
Fixing a small bug resulting from extracting the method `extractPathFromUrl`

 **JIRA**: N/A
 **Linked PRs**: https://github.com/mobify/platform-scaffold/pull/440

## Changes
- Use the constructed `urlObject` to get the hash instead of the `url` string.

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Open the hamburger navigation
- Navigate to one of the entries (this is where it was broken previously)
