### PR TITLE
Update to latest released astro version

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "babel-runtime": "6.11.6",
     "bluebird": "^2.9.34",
-    "mobify-progressive-app-sdk": "1.0.0-beta",
+    "mobify-progressive-app-sdk": "1.0.0-beta2",
     "webpack": "^2.2.0-rc.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates to the latest released version of the progressive-app-sdk

## Changes
- Update package.json in native folder

## How to test-drive this PR
- `cd native && npm run deps`
- Run app, no need for preview
