### PR TITLE
Don't show preloader if running in Astro

### DIFF
--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -45,7 +45,9 @@ const asyncInitApp = () => {
 }
 
 if (isReactRoute()) {
-    displayPreloader(preloadCSS, preloadHTML, preloadJS)
+    if (!isRunningInAstro) {
+        displayPreloader(preloadCSS, preloadHTML, preloadJS)
+    }
 
     // Create React mounting target
     const body = document.getElementsByTagName('body')[0]


### PR DESCRIPTION
In Astro,  until we decide whether we want to show a preloader and what that preloader will look like, we'll disable the preloader.

 **JIRA**: https://mobify.atlassian.net/browse/HYB-1040

## Changes
- Don't display preloader if in Astro

## How to test-drive this PR
- Run `npm run dev`
- Preview in app by running app (preview is on by default)
- You shouldn't see any header preloader when opening the cart, for example
