### PR TITLE
Initial steps for runtime type checking

### DIFF
--- a/web/app/integration-manager/products/responses.js
+++ b/web/app/integration-manager/products/responses.js
@@ -23,7 +23,6 @@ const Breadcrumb = Runtypes.Record({
 const ProductUIData = Runtypes.Record({
     breadcrumbs: Runtypes.Array(Breadcrumb),
     uenc: Runtypes.String,
-    formInfo: Runtypes.Always,
     itemQuantity: Runtypes.Number,
     ctaText: Runtypes.String
 })

--- a/web/app/integration-manager/products/responses.js
+++ b/web/app/integration-manager/products/responses.js
@@ -1,7 +1,18 @@
-import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
 import {createAction as createReduxAction} from 'redux-actions'
 
 import * as Runtypes from 'runtypes'
+
+const Nullable = (type) => Runtypes.Union(type, Runtypes.Null, Runtypes.Undefined)
+
+const Link = Runtypes.Record({
+    href: Runtypes.String,
+    text: Runtypes.String
+})
+
+const Image = Runtypes.Record({
+    alt: Runtypes.String,
+    src: Runtypes.String
+})
 
 const Breadcrumb = Runtypes.Record({
     href: Runtypes.String,
@@ -37,6 +48,36 @@ export const receiveProductDetailsUIData = createTypedAction(
     Runtypes.Dictionary(ProductUIData)
 )
 
-export const receiveProductDetailsProductData = createAction('Receive Product Details product data')
+const CarouselItem = Runtypes.Optional({
+    thumb: Nullable(Runtypes.String),
+    img: Runtypes.String,
+    full: Runtypes.String,
+    caption: Nullable(Runtypes.String),
+    position: Runtypes.String,
+    isMain: Runtypes.Boolean
+})
 
-export const receiveProductListProductData = createAction('Receive ProductList product data')
+const ProductDetailsData = Runtypes.Record({
+    title: Runtypes.String,
+    price: Runtypes.String,
+    carouselItems: Runtypes.Array(CarouselItem),
+    description: Runtypes.String
+})
+
+const ProductDetailsListData = Runtypes.Record({
+    title: Runtypes.String,
+    price: Runtypes.String,
+    carouselItems: Runtypes.Array(CarouselItem),
+    link: Link,
+    image: Image
+})
+
+export const receiveProductDetailsProductData = createTypedAction(
+    'Receive Product Details product data',
+    Runtypes.Dictionary(ProductDetailsData)
+)
+
+export const receiveProductListProductData = createTypedAction(
+    'Receive ProductList product data',
+    Runtypes.Dictionary(ProductDetailsListData)
+)

--- a/web/app/integration-manager/products/responses.js
+++ b/web/app/integration-manager/products/responses.js
@@ -1,22 +1,6 @@
-import {createAction as createReduxAction} from 'redux-actions'
-
 import * as Runtypes from 'runtypes'
 import {ProductUIData, ProductDetailsData, ProductDetailsListData} from './types'
-
-const typecheck = (type, value) => {
-    try {
-        type.check(value)
-    } catch (e) {
-        console.info(e)
-        console.log(value)
-    }
-    return value
-}
-
-const createTypedAction = (description, type) => createReduxAction(
-    description,
-    (payload) => typecheck(type, payload)
-)
+import {createTypedAction} from '../../utils/utils'
 
 export const receiveProductDetailsUIData = createTypedAction(
     'Receive Product Details UI data',

--- a/web/app/integration-manager/products/responses.js
+++ b/web/app/integration-manager/products/responses.js
@@ -1,6 +1,41 @@
 import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
+import {createAction as createReduxAction} from 'redux-actions'
 
-export const receiveProductDetailsUIData = createAction('Receive Product Details UI data')
+import * as Runtypes from 'runtypes'
+
+const Breadcrumb = Runtypes.Record({
+    href: Runtypes.String,
+    text: Runtypes.String,
+    title: Runtypes.String
+})
+
+const ProductUIData = Runtypes.Record({
+    breadcrumbs: Runtypes.Array(Breadcrumb),
+    uenc: Runtypes.String,
+    formInfo: Runtypes.Always,
+    itemQuantity: Runtypes.Number,
+    ctaText: Runtypes.String
+})
+
+const typecheck = (type, value) => {
+    try {
+        type.check(value)
+    } catch (e) {
+        console.info(e)
+        console.log(value)
+    }
+    return value
+}
+
+const createTypedAction = (description, type) => createReduxAction(
+    description,
+    (payload) => typecheck(type, payload)
+)
+
+export const receiveProductDetailsUIData = createTypedAction(
+    'Receive Product Details UI data',
+    Runtypes.Dictionary(ProductUIData)
+)
 
 export const receiveProductDetailsProductData = createAction('Receive Product Details product data')
 

--- a/web/app/integration-manager/products/responses.js
+++ b/web/app/integration-manager/products/responses.js
@@ -1,31 +1,7 @@
 import {createAction as createReduxAction} from 'redux-actions'
 
 import * as Runtypes from 'runtypes'
-
-const Nullable = (type) => Runtypes.Union(type, Runtypes.Null, Runtypes.Undefined)
-
-const Link = Runtypes.Record({
-    href: Runtypes.String,
-    text: Runtypes.String
-})
-
-const Image = Runtypes.Record({
-    alt: Runtypes.String,
-    src: Runtypes.String
-})
-
-const Breadcrumb = Runtypes.Record({
-    href: Runtypes.String,
-    text: Runtypes.String,
-    title: Runtypes.String
-})
-
-const ProductUIData = Runtypes.Record({
-    breadcrumbs: Runtypes.Array(Breadcrumb),
-    uenc: Runtypes.String,
-    itemQuantity: Runtypes.Number,
-    ctaText: Runtypes.String
-})
+import {ProductUIData, ProductDetailsData, ProductDetailsListData} from './types'
 
 const typecheck = (type, value) => {
     try {
@@ -46,30 +22,6 @@ export const receiveProductDetailsUIData = createTypedAction(
     'Receive Product Details UI data',
     Runtypes.Dictionary(ProductUIData)
 )
-
-const CarouselItem = Runtypes.Optional({
-    thumb: Nullable(Runtypes.String),
-    img: Runtypes.String,
-    full: Runtypes.String,
-    caption: Nullable(Runtypes.String),
-    position: Runtypes.String,
-    isMain: Runtypes.Boolean
-})
-
-const ProductDetailsData = Runtypes.Record({
-    title: Runtypes.String,
-    price: Runtypes.String,
-    carouselItems: Runtypes.Array(CarouselItem),
-    description: Runtypes.String
-})
-
-const ProductDetailsListData = Runtypes.Record({
-    title: Runtypes.String,
-    price: Runtypes.String,
-    carouselItems: Runtypes.Array(CarouselItem),
-    link: Link,
-    image: Image
-})
 
 export const receiveProductDetailsProductData = createTypedAction(
     'Receive Product Details product data',

--- a/web/app/integration-manager/products/types.js
+++ b/web/app/integration-manager/products/types.js
@@ -1,0 +1,45 @@
+import * as Runtypes from 'runtypes'
+
+export const Nullable = (type) => Runtypes.Union(type, Runtypes.Null, Runtypes.Undefined)
+
+export const Link = Runtypes.Record({
+    href: Runtypes.String,
+    text: Runtypes.String,
+    title: Nullable(Runtypes.String)
+})
+
+export const Image = Runtypes.Record({
+    alt: Runtypes.String,
+    src: Runtypes.String
+})
+
+export const ProductUIData = Runtypes.Record({
+    breadcrumbs: Runtypes.Array(Link),
+    uenc: Runtypes.String,
+    itemQuantity: Runtypes.Number,
+    ctaText: Runtypes.String
+})
+
+export const CarouselItem = Runtypes.Optional({
+    thumb: Nullable(Runtypes.String),
+    img: Runtypes.String,
+    full: Runtypes.String,
+    caption: Nullable(Runtypes.String),
+    position: Runtypes.String,
+    isMain: Runtypes.Boolean
+})
+
+export const ProductDetailsData = Runtypes.Record({
+    title: Runtypes.String,
+    price: Runtypes.String,
+    carouselItems: Runtypes.Array(CarouselItem),
+    description: Runtypes.String
+})
+
+export const ProductDetailsListData = Runtypes.Record({
+    title: Runtypes.String,
+    price: Runtypes.String,
+    carouselItems: Runtypes.Array(CarouselItem),
+    link: Link,
+    image: Image
+})

--- a/web/app/utils/utils.js
+++ b/web/app/utils/utils.js
@@ -1,3 +1,4 @@
+import {createAction as createReduxAction} from 'redux-actions'
 
 /**
  * Wraps an action creator function so that the React synthetic action
@@ -45,3 +46,19 @@ export const splitFullName = (fullname) => {
         lastname: names.slice(-1).join(' ')
     }
 }
+
+
+const typecheck = (type, value) => {
+    try {
+        type.check(value)
+    } catch (e) {
+        console.info(e)
+        console.log(value)
+    }
+    return value
+}
+
+export const createTypedAction = (description, type) => createReduxAction(
+    description,
+    (payload) => typecheck(type, payload)
+)

--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,7 @@
     "redux-thunk": "2.2.0",
     "reselect": "3.0.0",
     "reselect-immutable-helpers": "1.2.2",
-    "runtypes": "0.9.1",
+    "runtypes": "0.9.2",
     "webfontloader": "1.6.27",
     "whatwg-fetch": "1.0.0"
   },

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "redux-thunk": "2.2.0",
     "reselect": "3.0.0",
     "reselect-immutable-helpers": "1.2.2",
+    "runtypes": "0.9.1",
     "webfontloader": "1.6.27",
     "whatwg-fetch": "1.0.0"
   },


### PR DESCRIPTION
This PR makes an initial attempt at runtime type checking of responses using the `runtypes` library. This is a lightweight library that implements type definitions inspired by TypeScript that can be used to validate data at runtime. 

Currently the type validation is all in the `responses.js` file; I envision the type definitions moving to their own file and some sort of webpack configuration importing either the type checking code or a stub. (with some of the functions becoming global utilities)

 **JIRA**: N/A

## Changes
- (change1)

## How to test-drive this PR
- (necessary config changes)
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- (how to access the new / changed functionality -- fixtures, URLs)
