### PR TITLE
Convert urlToPathKey to use the SDK version

### DIFF
--- a/web/app/containers/app/reducer.js
+++ b/web/app/containers/app/reducer.js
@@ -1,7 +1,7 @@
 import {handleActions} from 'redux-actions'
 import {fromJS, List} from 'immutable'
 import {mergePayload} from '../../utils/reducer-utils'
-import {urlToPathKey} from '../../utils/utils'
+import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 
 import * as appActions from './actions'
 

--- a/web/app/containers/app/selectors.js
+++ b/web/app/containers/app/selectors.js
@@ -1,7 +1,7 @@
 import {createSelector} from 'reselect'
 import {createGetSelector, createHasSelector} from 'reselect-immutable-helpers'
 import {getUi} from '../../store/selectors'
-import {urlToPathKey} from '../../utils/utils'
+import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 import {CURRENT_URL, FETCHED_PATHS} from './constants'
 
 export const getApp = createSelector(getUi, ({app}) => app)

--- a/web/app/containers/cart/actions.js
+++ b/web/app/containers/cart/actions.js
@@ -1,6 +1,6 @@
 import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
 import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
-import {urlToPathKey} from '../../utils/utils'
+import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 import {closeModal, openModal} from 'progressive-web-sdk/dist/store/modals/actions'
 import {fetchShippingMethodsEstimate} from '../../store/checkout/shipping/actions'
 import {

--- a/web/app/containers/navigation/container.js
+++ b/web/app/containers/navigation/container.js
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
-import {extractPathFromURL} from '../../utils/utils'
+import {extractPathFromURL} from 'progressive-web-sdk/dist/utils/utils'
 import {createPropsSelector} from 'reselect-immutable-helpers'
 
 import Nav from 'progressive-web-sdk/dist/components/nav'

--- a/web/app/integration-manager/_demandware-connector/categories/commands.js
+++ b/web/app/integration-manager/_demandware-connector/categories/commands.js
@@ -1,4 +1,4 @@
-import {urlToPathKey} from '../../../utils/utils'
+import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 import {makeDemandwareRequest} from '../utils'
 import {receiveCategory} from '../../categories/responses'
 import {receiveProductListProductData} from '../../products/responses'

--- a/web/app/integration-manager/_demandware-connector/products/commands.js
+++ b/web/app/integration-manager/_demandware-connector/products/commands.js
@@ -1,6 +1,6 @@
 import {browserHistory} from 'progressive-web-sdk/dist/routing'
 import {receiveProductDetailsProductData, receiveProductDetailsUIData} from '../../products/responses'
-import {urlToPathKey} from '../../../utils/utils'
+import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 import {makeDemandwareRequest} from '../utils'
 import {parseProductDetails, getCurrentProductID, getProductHref} from '../parsers'
 import {API_END_POINT_URL} from '../constants'

--- a/web/app/integration-manager/_merlins-connector/categories/commands.js
+++ b/web/app/integration-manager/_merlins-connector/categories/commands.js
@@ -1,4 +1,4 @@
-import {urlToPathKey} from '../../../utils/utils'
+import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 import {receiveCategory} from '../../categories/responses'
 import {receiveProductListProductData} from '../../products/responses'
 import categoryProductsParser from './parser'

--- a/web/app/integration-manager/_merlins-connector/categories/parser.js
+++ b/web/app/integration-manager/_merlins-connector/categories/parser.js
@@ -1,5 +1,5 @@
 import {parseTextLink, getTextFrom} from '../../../utils/parser-utils'
-import {urlToPathKey} from '../../../utils/utils'
+import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 
 const categoryProductsParser = ($, $html) => {
     const $numItems = $html.find('#toolbar-amount .toolbar-number').first()

--- a/web/app/integration-manager/_merlins-connector/products/commands.js
+++ b/web/app/integration-manager/_merlins-connector/products/commands.js
@@ -1,4 +1,4 @@
-import {urlToPathKey} from '../../../utils/utils'
+import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 import {receiveFormInfo} from '../actions'
 
 import {fetchPageData} from '../app/commands'

--- a/web/app/integration-manager/_merlins-connector/products/parsers.js
+++ b/web/app/integration-manager/_merlins-connector/products/parsers.js
@@ -1,6 +1,6 @@
 import {extractMagentoJson} from '../../../utils/magento-utils'
 import {getTextFrom, parseTextLink, parseImage} from '../../../utils/parser-utils'
-import {urlToPathKey} from '../../../utils/utils'
+import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 
 const UENC_REGEX = /\/uenc\/([^/]+),\//
 

--- a/web/app/store/categories/actions.js
+++ b/web/app/store/categories/actions.js
@@ -1,5 +1,5 @@
 import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
-import {urlToPathKey} from '../../utils/utils'
+import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 import productListParser from './parsers/product-list'
 
 export const receiveCategory = createAction('Receive Category Data')

--- a/web/app/utils/utils.js
+++ b/web/app/utils/utils.js
@@ -10,28 +10,6 @@ export const stripEvent = (fn) =>
 /* istanbul ignore next */
     () => fn()
 
-
-/**
-* Converts a URL to the relative URL
-* @param {string} url - the url to be converted (if it's already relative it will be returned as is)
-* @param {bool} includeHash - indicates if the URL hash should be included in the relative URL returns
-*/
-export const extractPathFromURL = (url, includeHash) => {
-    if (/^\//.test(url)) {
-        // The URL is already relative, so just return it
-        return url
-    }
-    const urlObject = new URL(url)
-
-    return `${urlObject.pathname}${urlObject.search}${includeHash ? urlObject.hash : ''}`
-}
-
-/**
- * Converts a full URL to the preferred format for keying the redux store,
- * i.e. the path and query string
- */
-export const urlToPathKey = (url) => extractPathFromURL(url, false)
-
 /**
  * Returns a path given a `location` object.
  * @param {object} location - a location object from React Router


### PR DESCRIPTION
This PR removes the `urlToPathKey` function from the scaffold in favour of the version found in SDK 0.14.1. 

 **JIRA**: N/A

## Changes
- Change all imports to get the function from the SDK
- Remove the local definition

## How to test-drive this PR
- `npm i`
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Make sure nothing has broken.
