### PR TITLE
Clean up product code a little

### DIFF
--- a/web/app/containers/product-details/selectors.js
+++ b/web/app/containers/product-details/selectors.js
@@ -45,7 +45,6 @@ export const getAddToCartDisabled = createSelector(
 
 export const getItemQuantity = createGetSelector(getSelectedProductDetails, 'itemQuantity')
 export const getCTAText = createGetSelector(getSelectedProductDetails, 'ctaText', 'Add To Cart')
-export const getFormInfo = createGetSelector(getSelectedProductDetails, 'formInfo')
 
 export const getProductDetailsBreadcrumbs = createGetSelector(
     getSelectedProductDetails,

--- a/web/app/integration-manager/_merlins-connector/products/commands.js
+++ b/web/app/integration-manager/_merlins-connector/products/commands.js
@@ -15,7 +15,7 @@ export const fetchPdpData = (url) => (dispatch) => {
 
             dispatch(receiveProductDetailsUIData({[pathKey]: productDetailsUIParser($, $response)}))
             dispatch(receiveProductDetailsProductData({[pathKey]: productDetailsParser($, $response)}))
-            dispatch(receiveFormInfo({[pathKey]: pdpAddToCartFormParser($, $response).formInfo}))
+            dispatch(receiveFormInfo({[pathKey]: pdpAddToCartFormParser($, $response)}))
         })
         .catch((error) => { console.info(error.message) })
 }

--- a/web/app/integration-manager/_merlins-connector/products/parsers.js
+++ b/web/app/integration-manager/_merlins-connector/products/parsers.js
@@ -39,12 +39,6 @@ export const productDetailsUIParser = ($, $html) => {
     const $mainContent = $html.find('.page-main')
     const $form = $mainContent.find('#product_addtocart_form')
 
-    const hiddenInputs = {}
-    $form.find('input[type="hidden"]').each((idx, input) => {
-        const $input = $(input)
-        hiddenInputs[$input.attr('name')] = $input.val()
-    })
-
     const submitUrl = $form.attr('action')
     const uencMatch = UENC_REGEX.exec(submitUrl)
     const uenc = uencMatch ? uencMatch[1] : ''
@@ -52,11 +46,6 @@ export const productDetailsUIParser = ($, $html) => {
     return {
         breadcrumbs: parseBreadcrumbs($, $breadcrumbs),
         uenc,
-        formInfo: {
-            submitUrl: $form.attr('action'),
-            method: $form.attr('method'),
-            hiddenInputs
-        },
         itemQuantity: parseInt($form.find('#qty').val()),
         ctaText: $form.find('.tocart').text()
     }

--- a/web/app/integration-manager/_merlins-connector/products/parsers.js
+++ b/web/app/integration-manager/_merlins-connector/products/parsers.js
@@ -36,11 +36,9 @@ export const productDetailsUIParser = ($, $html) => {
             .find('a')
     )
 
-    const $mainContent = $html.find('.page-main')
-    const $form = $mainContent.find('#product_addtocart_form')
+    const $form = $html.find('.page-main #product_addtocart_form')
 
-    const submitUrl = $form.attr('action')
-    const uencMatch = UENC_REGEX.exec(submitUrl)
+    const uencMatch = UENC_REGEX.exec($form.attr('action'))
     const uenc = uencMatch ? uencMatch[1] : ''
 
     return {
@@ -52,8 +50,7 @@ export const productDetailsUIParser = ($, $html) => {
 }
 
 export const pdpAddToCartFormParser = ($, $html) => {
-    const $mainContent = $html.find('.page-main')
-    const $form = $mainContent.find('#product_addtocart_form')
+    const $form = $html.find('.page-main #product_addtocart_form')
 
     const hiddenInputs = {}
     $form.find('input[type="hidden"]').each((idx, input) => {
@@ -76,7 +73,7 @@ export const productListParser = ($, $html) => {
         const link = parseTextLink($product.find('.product-item-link'))
         const image = parseImage($product.find('.product-image-photo'))
         productMap[urlToPathKey(link.href)] = {
-            title: link.text.trim(),
+            title: link.text,
             price: getTextFrom($product, '.price'),
             link,
             image,

--- a/web/app/integration-manager/_merlins-connector/products/parsers.js
+++ b/web/app/integration-manager/_merlins-connector/products/parsers.js
@@ -62,13 +62,9 @@ export const pdpAddToCartFormParser = ($, $html) => {
     })
 
     return {
-        formInfo: {
-            submitUrl: $form.attr('action'),
-            method: $form.attr('method'),
-            hiddenInputs
-        },
-        itemQuantity: parseInt($form.find('#qty').val()),
-        ctaText: $form.find('.tocart').text()
+        submitUrl: $form.attr('action'),
+        method: $form.attr('method'),
+        hiddenInputs
     }
 }
 

--- a/web/app/integration-manager/_merlins-connector/products/parsers.test.js
+++ b/web/app/integration-manager/_merlins-connector/products/parsers.test.js
@@ -35,19 +35,6 @@ describe('the ProductDetails product parser', () => {
     })
 })
 
-describe('the ProductDetails UI parser', () => {
-    const $content = jquerifyHtmlFile(`${__dirname}/product-details-example.html`)
-    const parsedContent = productDetailsUIParser($, $content)
-
-    test('extracts form info from the add-to-cart form', () => {
-        expect(isURL(parsedContent.formInfo.submitUrl)).toBe(true)
-        expect(parsedContent.formInfo.method).toBe('post')
-        Object.keys(parsedContent.formInfo.hiddenInputs).forEach((key) => {
-            expect(typeof parsedContent.formInfo.hiddenInputs[key]).toBe('string')
-        })
-    })
-})
-
 describe('the ProductList product parser', () => {
     const $content = jquerifyHtmlFile(`${__dirname}/product-list.test.html`)
     const parsedContent = productListParser($, $content)

--- a/web/app/integration-manager/_merlins-connector/products/parsers.test.js
+++ b/web/app/integration-manager/_merlins-connector/products/parsers.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jquery, jest, node */
 import {jquerifyHtmlFile} from 'progressive-web-sdk/dist/test-utils'
 import {isURL} from 'validator'
-import {productDetailsParser, productDetailsUIParser, productListParser} from './parsers'
+import {productDetailsParser, productListParser} from './parsers'
 
 /* eslint-disable max-nested-callbacks */
 


### PR DESCRIPTION
This PR prevents some unnecessary work and removes the `formInfo` from the `ui->product-details` store branch, since it is now handled entirely within the Merlin's connector. This simplifies the Product Details UI parser significantly.

 **JIRA**: Preparatory for moving to the SDK

## Changes
- Don't pass the `formInfo` to the UI branch
- Don't parse extra data in the form parser that is immediately discarded
- Miscellaneous changes.

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Visit a PDP and see that it still renders and works correctly.
