### PR TITLE
Update astro default bundle to be production

### DIFF
--- a/native/app/config/baseConfig.js
+++ b/native/app/config/baseConfig.js
@@ -15,7 +15,7 @@ const baseConfig = {
     baseURL: 'https://www.merlinspotions.com',
     previewBundle: AstroNative.Configuration.DEBUG
         ? localPreviewUrl
-        : '//cdn.mobify.com/sites/progressive-web-scaffold/astro/loader.js',
+        : '//cdn.mobify.com/sites/progressive-web-scaffold/production/loader.js',
     colors,
     logoUrl: 'file:///logo.png',
     previewEnabled


### PR DESCRIPTION
I noticed we were still using the old version that we published to get around issues with not having a published bundle when we started development. We should point this to the production bundle.

## Changes
- Change CDN URL to point to `production` instead of `astro`

## How to test-drive this PR
- Run app in Release Mode
- Should work as expected
