### PR TITLE
WEB-1327: do not display sign in when user is loggedIn

### DIFF
--- a/web/app/containers/cart/partials/cart-product-list.jsx
+++ b/web/app/containers/cart/partials/cart-product-list.jsx
@@ -6,6 +6,8 @@ import {createPropsSelector} from 'reselect-immutable-helpers'
 import {updateItemQuantity} from '../../../store/cart/actions'
 import {openRemoveItemModal, saveToWishlist} from '../actions'
 import {getCartItems, getCartSummaryCount} from '../../../store/cart/selectors'
+import {getIsLoggedIn} from '../../app/selectors'
+
 import {noop} from 'progressive-web-sdk/dist/utils/utils'
 
 import Button from 'progressive-web-sdk/dist/components/button'
@@ -152,7 +154,7 @@ CartProductItem.propTypes = {
     onSaveLater: PropTypes.func
 }
 
-const CartProductList = ({items, summaryCount, onSaveLater, onUpdateItemQuantity, openRemoveItemModal, onOpenSignIn}) => {
+const CartProductList = ({items, isLoggedIn, summaryCount, onSaveLater, onUpdateItemQuantity, openRemoveItemModal, onOpenSignIn}) => {
     const isCartEmpty = items.length === 0
 
     return (
@@ -162,10 +164,12 @@ const CartProductList = ({items, summaryCount, onSaveLater, onUpdateItemQuantity
                     <h1 className="u-flex u-text-uppercase">
                         Cart {summaryCount > 0 && <span className="u-text-lighter">({summaryCount} Items)</span>}
                     </h1>
-                    <Button className="u-flex-none u-color-brand u-text-letter-spacing-normal" onClick={onOpenSignIn}>
-                        <Icon name="user" />
-                        Sign in
-                    </Button>
+                    {!isLoggedIn &&
+                        <Button className="u-flex-none u-color-brand u-text-letter-spacing-normal" onClick={onOpenSignIn}>
+                            <Icon name="user" />
+                            Sign in
+                        </Button>
+                    }
                 </div>
             </div>
 
@@ -178,6 +182,7 @@ const CartProductList = ({items, summaryCount, onSaveLater, onUpdateItemQuantity
 }
 
 CartProductList.propTypes = {
+    isLoggedIn: PropTypes.bool,
     items: PropTypes.array,
     openRemoveItemModal: PropTypes.func,
     summaryCount: PropTypes.number,
@@ -188,7 +193,8 @@ CartProductList.propTypes = {
 
 const mapStateToProps = createPropsSelector({
     items: getCartItems,
-    summaryCount: getCartSummaryCount
+    summaryCount: getCartSummaryCount,
+    isLoggedIn: getIsLoggedIn
 })
 
 const mapDispatchToProps = {


### PR DESCRIPTION
Sign in cta in cart for Merlins PWA is still visible when logged in

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1327

## Changes
- display 'sign in' only when user is not loggedIn

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Add an item to cart
- Go to cart
- Login then go to cart
