### PR TITLE
Re-enable the service worker since it’s become preview-aware

### DIFF
--- a/native/app/app.js
+++ b/native/app/app.js
@@ -66,7 +66,7 @@ window.run = async function() {
             previewController.presentPreviewAlert()
         })
 
-        const previewEnabled = baseConfig.previewEnabled
+        const previewEnabled = await previewController.isPreviewEnabled()
         if (previewEnabled) {
             runAppPreview()
         } else {

--- a/native/app/config/baseConfig.js
+++ b/native/app/config/baseConfig.js
@@ -9,16 +9,13 @@ const colors = {
     whiteColor: '#ffffff'
 }
 
-const previewEnabled = true
-
 const baseConfig = {
     baseURL: 'https://www.merlinspotions.com',
     previewBundle: AstroNative.Configuration.DEBUG
         ? localPreviewUrl
         : '//cdn.mobify.com/sites/progressive-web-scaffold/production/loader.js',
     colors,
-    logoUrl: 'file:///logo.png',
-    previewEnabled
+    logoUrl: 'file:///logo.png'
 }
 
 export default baseConfig

--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -87,8 +87,7 @@ if (isReactRoute()) {
 
     // load the worker if available
     // if no worker is available, we have to assume that promises might not be either.
-    // Astro doesn't currently support service workers
-    (('serviceWorker' in navigator && !isRunningInAstro)
+    (('serviceWorker' in navigator)
      ? loadWorker()
      : {then: (fn) => setTimeout(fn)}
     ).then(() => {


### PR DESCRIPTION
Also restore control of preview toggling to the PreviewController

 **JIRA**: https://mobify.atlassian.net/browse/HYB-1010
 **Linked PRs**: #304

## Changes
- Remove disable service worker in Astro check
- Restore control of preview toggling to the PreviewController

## How to test-drive this PR
- Run `npm run dev`
- Enable port forwarding to your Android device with chrome://inspect (localhost 8443)
- Run the Android app
- Shake to enable preview prompt
- Enable preview
- Kill app
- Make some local changes to your bundle you can easily verify
- Run app again
- Observe Preview display comes up
- Observe via Chrome Debugging tools a service worker exists
- Preview
- Observe your local changes are visible