### PR TITLE
Use only 1 cart

### DIFF
--- a/native/app/config/baseConfig.js
+++ b/native/app/config/baseConfig.js
@@ -9,7 +9,7 @@ const colors = {
     whiteColor: '#ffffff'
 }
 
-const previewEnabled = false
+const previewEnabled = true
 
 const baseConfig = {
     baseURL: 'https://www.merlinspotions.com',

--- a/native/app/config/baseConfig.js
+++ b/native/app/config/baseConfig.js
@@ -9,7 +9,7 @@ const colors = {
     whiteColor: '#ffffff'
 }
 
-const previewEnabled = true
+const previewEnabled = false
 
 const baseConfig = {
     baseURL: 'https://www.merlinspotions.com',

--- a/native/app/controllers/accountTabController.js
+++ b/native/app/controllers/accountTabController.js
@@ -39,10 +39,10 @@ const AccountTabController = function(viewPlugin, headerController, layout, segm
     })
 }
 
-AccountTabController.init = async function() {
-    const viewPlugin = await AnchoredLayoutPlugin.init()                // has the header and the layout with the segmentedView
-    const headerController = await TabHeaderController.init()           // header
-    const layout = await AnchoredLayoutPlugin.init()                    // has  the segmented view and the web views
+AccountTabController.init = async function(cartModalController) {
+    const viewPlugin = await AnchoredLayoutPlugin.init()                            // has the header and the layout with the segmentedView
+    const headerController = await TabHeaderController.init(cartModalController)    // header
+    const layout = await AnchoredLayoutPlugin.init()                                // has  the segmented view and the web views
     const segmentedView = await SegmentedPlugin.init()
     const signInView = await WebViewPlugin.init()
     const registerView = await WebViewPlugin.init()

--- a/native/app/controllers/cartModalController.js
+++ b/native/app/controllers/cartModalController.js
@@ -35,7 +35,11 @@ const CartModalController = function(modalView, navigationView) {
 
     this.navigationView.on('checkout:completed', () => {
         this.alertEnabled = false
-        AppEvents.trigger(AppEvents.cartNeedsUpdate)
+        // The merlin's backend needs a little extra time to process checkout
+        // so we wait for a small timeout and then try to update all webviews
+        setTimeout(() => {
+            AppEvents.trigger(AppEvents.cartNeedsUpdate)
+        }, 2000)
     })
 
     this.navigationView.on('cart:updated', () => {

--- a/native/app/controllers/cartModalController.js
+++ b/native/app/controllers/cartModalController.js
@@ -107,17 +107,21 @@ CartModalController.init = async function() {
     return cartModalController
 }
 
-CartModalController.prototype.show = function() {
+CartModalController.prototype.show = async function() {
     if (this.isShowing) {
         return
     }
+    const webView = await this.navigationView.getTopPlugin()
+    webView.reload()
     this.isShowing = true
+    this.alertEnabled = false
     this.viewPlugin.show({animated: true})
 }
 
-CartModalController.prototype.hide = async function() {
-    await this.viewPlugin.hide({animated: true})
+CartModalController.prototype.hide = function() {
+    this.viewPlugin.hide({animated: true})
     this.isShowing = false
+    this.navigationView.popToRoot()
 }
 
 CartModalController.prototype.isActiveItem = function() {

--- a/native/app/controllers/tabBarController.js
+++ b/native/app/controllers/tabBarController.js
@@ -5,6 +5,7 @@ import Application from 'progressive-app-sdk/application'
 import {tabBarConfig} from '../config/tabBarConfig'
 import baseConfig from '../config/baseConfig'
 
+import CartModalController from './cartModalController'
 import TabController from './tabController'
 import AccountTabController from './accountTabController'
 import AppEvents from '../global/app-events'
@@ -31,20 +32,21 @@ TabBarController.init = async function() {
     const tabBar = await TabBarPlugin.init()
     await tabBar.setColor(baseConfig.colors.primaryColor)
     const layout = await AnchoredLayoutPlugin.init()
+    const cartModalController = await CartModalController.init()
 
     const tabControllers = {}
 
     const tabControllerPromises = tabBarConfig.items.map((item) => {
         if (item.type === 'custom') {
             if (item.id === 'account') {
-                return AccountTabController.init().then((controller) => {
+                return AccountTabController.init(cartModalController).then((controller) => {
                     tabControllers[item.id] = controller
                 })
             } else {
                 return null
             }
         } else {
-            return TabController.init(item).then((controller) => {
+            return TabController.init(item, cartModalController).then((controller) => {
                 tabControllers[item.id] = controller
             })
         }

--- a/native/app/controllers/tabController.js
+++ b/native/app/controllers/tabController.js
@@ -17,7 +17,7 @@ const TabController = function(tabItem, layout, navigationView, headerController
     this.navigationView.navigateToUrl(tabItem.rootUrl)
 }
 
-TabController.init = async function(tabItem) {
+TabController.init = async function(tabItem, cartModalController) {
     const [
         layout,
         navigationView,
@@ -25,7 +25,7 @@ TabController.init = async function(tabItem) {
     ] = await Promise.all([
         AnchoredLayoutPlugin.init(),
         NavigationPlugin.init(),
-        TabHeaderController.init()
+        TabHeaderController.init(cartModalController)
     ])
 
     await layout.addTopView(headerController.viewPlugin)
@@ -48,7 +48,7 @@ TabController.init = async function(tabItem) {
         headerController.showCartModal()
     })
 
-    AppEvents.on(AppEvents.cartNeedsUpdate, async () => {
+    AppEvents.on(AppEvents.cartNeedsUpdate, () => {
         navigationView.trigger('cart:needs-update')
     })
 

--- a/native/app/controllers/tabHeaderController.js
+++ b/native/app/controllers/tabHeaderController.js
@@ -1,15 +1,14 @@
 import HeaderBarPlugin from 'progressive-app-sdk/plugins/headerBarPlugin'
 import CounterBadgeController from 'progressive-app-sdk/controllers/counterBadgeController'
 
-import CartModalController from './cartModalController'
-
 import AppEvents from '../global/app-events'
 import baseConfig from '../config/baseConfig'
 import cartConfig from '../config/cartConfig'
 
-const TabHeaderController = function(headerBar, counterBadgeController) {
+const TabHeaderController = function(headerBar, counterBadgeController, cartModalController) {
     this.viewPlugin = headerBar
     this.counterBadgeController = counterBadgeController
+    this.cartModalController = cartModalController
 
     headerBar.on(`click:${cartConfig.cartIcon.id}`, async () => {
         this.showCartModal()
@@ -20,7 +19,7 @@ const TabHeaderController = function(headerBar, counterBadgeController) {
     })
 }
 
-TabHeaderController.init = async function() {
+TabHeaderController.init = async function(cartModalController) {
     const headerBar = await HeaderBarPlugin.init()
     const counterBadgeController = await CounterBadgeController.init(cartConfig.cartIcon.imageUrl, 'headerId', {})
     const counterBadgePlugin = await counterBadgeController.generatePlugin()
@@ -31,16 +30,15 @@ TabHeaderController.init = async function() {
     await headerBar.setBackgroundColor(baseConfig.colors.primaryColor)
     await headerBar.setOpaque()
 
-    return new TabHeaderController(headerBar, counterBadgeController)
+    return new TabHeaderController(headerBar, counterBadgeController, cartModalController)
 }
 
 TabHeaderController.prototype.updateCounter = function(count) {
     this.counterBadgeController.updateCounterValue(count)
 }
 
-TabHeaderController.prototype.showCartModal = async () => {
-    const cartModalController = await CartModalController.init()
-    cartModalController.show()
+TabHeaderController.prototype.showCartModal = function() {
+    this.cartModalController.show()
 }
 
 export default TabHeaderController


### PR DESCRIPTION
Previously we were creating a new cart every time we wanted to open it. These carts were never released and you end up with a bunch of orphaned controllers/webviews. We now create one cart and reuse it.

 **JIRA**: https://mobify.atlassian.net/browse/HYB-1025

## Changes
- Pass around one cart modal controller

## How to test-drive this PR
- Run app
- Open/close cart a bunch of times
- See in Safari that only one cart has been created/is instantiated
