### PR TITLE
Use relative paths for components in the READMEs

### DIFF
--- a/web/app/components/lazy-load-content/README.md
+++ b/web/app/components/lazy-load-content/README.md
@@ -1,6 +1,6 @@
 ```js
 // JS, importing the local component
-import LazyLoadContent from 'components/lazy-load-content'
+import LazyLoadContent from '../components'/lazy-load-content'
 ```
 
 

--- a/web/app/components/lazy-load-content/README.md
+++ b/web/app/components/lazy-load-content/README.md
@@ -1,6 +1,6 @@
 ```js
 // JS, importing the local component
-import LazyLoadContent from '../components'/lazy-load-content'
+import LazyLoadContent from '../components/lazy-load-content'
 ```
 
 

--- a/web/app/components/notification-manager/README.md
+++ b/web/app/components/notification-manager/README.md
@@ -8,4 +8,4 @@
 
 ## Import With
 
-`import NotificationManager from 'components/notification-manager'`
+`import NotificationManager from '../components'/notification-manager'`

--- a/web/app/components/notification-manager/README.md
+++ b/web/app/components/notification-manager/README.md
@@ -8,4 +8,4 @@
 
 ## Import With
 
-`import NotificationManager from '../components'/notification-manager'`
+`import NotificationManager from '../components/notification-manager'`

--- a/web/app/components/notification/README.md
+++ b/web/app/components/notification/README.md
@@ -7,4 +7,4 @@
 
 ## Import With
 
-`import Notification from 'components/notification'`
+`import Notification from '../components'/notification'`

--- a/web/app/components/notification/README.md
+++ b/web/app/components/notification/README.md
@@ -7,4 +7,4 @@
 
 ## Import With
 
-`import Notification from '../components'/notification'`
+`import Notification from '../components/notification'`

--- a/web/app/components/product-item/README.md
+++ b/web/app/components/product-item/README.md
@@ -1,6 +1,6 @@
 ```js
 // JS, importing the local component
-import ProductItem from '../components'/product-item'
+import ProductItem from '../components/product-item'
 
 // SCSS, importing the local component styles to app/styles/_components.scss
 @import '../components/product-item/base';

--- a/web/app/components/product-item/README.md
+++ b/web/app/components/product-item/README.md
@@ -1,6 +1,6 @@
 ```js
 // JS, importing the local component
-import ProductItem from 'components/product-item'
+import ProductItem from '../components'/product-item'
 
 // SCSS, importing the local component styles to app/styles/_components.scss
 @import '../components/product-item/base';


### PR DESCRIPTION
The component README files were generated with incorrect import statements for the Javascript of the component. This fixes them so that no tool thinks we're missing a dependency called `components`.

 **JIRA**:  N/A