### PR TITLE
WEB-1333: add a condition to not display controls when there is 1 image

### DIFF
--- a/web/app/containers/product-details/partials/product-details-carousel.jsx
+++ b/web/app/containers/product-details/partials/product-details-carousel.jsx
@@ -14,7 +14,8 @@ const ProductDetailsCarousel = ({items, contentsLoaded}) => {
         previousIcon: 'chevron-left',
         nextIcon: 'chevron-right',
         iconSize: 'medium',
-        className: 'pw--frame pw--side-controls t-product-details__carousel u-padding-md u-bg-color-neutral-10'
+        className: 'pw--frame pw--side-controls t-product-details__carousel u-padding-md u-bg-color-neutral-10',
+        showControls: (items.length > 1) ? true : false
     }
 
     // So long as we have items, display the carousel as intended!

--- a/web/app/containers/product-details/partials/product-details-carousel.jsx
+++ b/web/app/containers/product-details/partials/product-details-carousel.jsx
@@ -15,7 +15,7 @@ const ProductDetailsCarousel = ({items, contentsLoaded}) => {
         nextIcon: 'chevron-right',
         iconSize: 'medium',
         className: 'pw--frame pw--side-controls t-product-details__carousel u-padding-md u-bg-color-neutral-10',
-        showControls: (items.length > 1) ? true : false
+        showControls: items.length > 1 && true
     }
 
     // So long as we have items, display the carousel as intended!


### PR DESCRIPTION
hide pips and image navigation when there is only one image

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1333

## Changes
- add a condition to not display controls when there is 1 image

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- [Go to PDP](https://www.merlinspotions.com/unicorn-blood.html)
