### PR TITLE
No longer parse plp text

### DIFF
--- a/web/app/containers/product-list/partials/product-list-contents.jsx
+++ b/web/app/containers/product-list/partials/product-list-contents.jsx
@@ -10,6 +10,8 @@ import SkeletonBlock from 'progressive-web-sdk/dist/components/skeleton-block'
 
 import ProductTile from './product-tile'
 
+const noResultsText = 'We can\'t find products matching the selection'
+
 const ResultList = ({products}) => (
     <List className="c--borderless">
         {products.map((product, idx) => <ProductTile key={idx} {...product} />)}
@@ -20,7 +22,7 @@ ResultList.propTypes = {
     products: PropTypes.array
 }
 
-const NoResultsList = ({bodyText}) => (
+const NoResultsList = () => (
     <div className="u-flexbox u-direction-column u-align-center">
         <Image
             className="u-flex-none"
@@ -30,7 +32,7 @@ const NoResultsList = ({bodyText}) => (
             src={getAssetUrl('static/img/global/no-results.png')} />
 
         <div className="t-product-list__no-results-text u-text-align-center">
-            {bodyText}
+            {noResultsText}
         </div>
     </div>
 )
@@ -39,7 +41,7 @@ NoResultsList.propTypes = {
     bodyText: PropTypes.string
 }
 
-const ProductListContents = ({contentsLoaded, numItems, products, hasProducts, noResultsText}) => (
+const ProductListContents = ({contentsLoaded, numItems, products, hasProducts}) => (
     <div className="t-product-list__container u-padding-end u-padding-bottom-lg u-padding-start">
         <div className="t-product-list__num-results u-padding-md">
             {contentsLoaded ?
@@ -49,7 +51,7 @@ const ProductListContents = ({contentsLoaded, numItems, products, hasProducts, n
             }
         </div>
 
-        {(hasProducts || !contentsLoaded) ? <ResultList products={products} /> : <NoResultsList bodyText={noResultsText} />}
+        {(hasProducts || !contentsLoaded) ? <ResultList products={products} /> : <NoResultsList />}
     </div>
 )
 
@@ -57,14 +59,12 @@ ProductListContents.propTypes = {
     products: PropTypes.array.isRequired,
     contentsLoaded: PropTypes.bool,
     hasProducts: PropTypes.bool,
-    noResultsText: PropTypes.string,
     numItems: PropTypes.string
 }
 
 const mapStateToProps = createPropsSelector({
     hasProducts: selectors.getHasProducts,
     contentsLoaded: selectors.getProductListContentsLoaded,
-    noResultsText: selectors.getNoResultsText,
     numItems: selectors.getNumItems,
     products: selectors.getProductListProducts
 })

--- a/web/app/containers/product-list/selectors.js
+++ b/web/app/containers/product-list/selectors.js
@@ -31,7 +31,6 @@ export const getNumItems = createGetSelector(getSelectedCategory, 'itemCount')
 export const getProductListTitle = createGetSelector(getSelectedCategory, 'title')
 export const getProductListParentHref = createGetSelector(getSelectedCategory, 'parentHref', '/')
 export const getProductListParentName = createGetSelector(getSelectedCategory, 'parentName', 'Home')
-export const getNoResultsText = createGetSelector(getSelectedCategory, 'noResultsText')
 
 export const getProductListProducts = createSelector(
     getProducts,

--- a/web/app/integration-manager/_merlins-connector/categories/parser.js
+++ b/web/app/integration-manager/_merlins-connector/categories/parser.js
@@ -12,7 +12,6 @@ const categoryProductsParser = ($, $html) => {
           .map(urlToPathKey)
 
     return {
-        noResultsText: getTextFrom($html, '.message.empty'),
         itemCount: $numItems.length > 0 ? $numItems.text() : '0',
         products,
         title: getTextFrom($html, '.page-title')

--- a/web/app/integration-manager/_merlins-connector/categories/parser.test.js
+++ b/web/app/integration-manager/_merlins-connector/categories/parser.test.js
@@ -8,9 +8,6 @@ describe('the product list parser', () => {
 
     it('should extract the product list content from the rendered HTML', () => {
         const expected = {
-            hasProducts: true,
-            contentsLoaded: true,
-            noResultsText: '',
             itemCount: '7',
             title: 'Potions',
             productUrls: [


### PR DESCRIPTION
The text on the PLP when there were no available products was parsed out of the PLP HTML. This PR removes that in favour of a built-in string. 

 **JIRA**: N/A

## Changes
- Use a string in the code rather than a parsed string when there are no items
- No longer pick out the string in the Merlin's parser.

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Go to an empty category (e.g. Charms)
- See that there is still text
- See that the text is not stored in the categories branch of the Redux store.
