### PR TITLE
[Integration Manager] Fix interaction between Loadable and Template HoCs.

### DIFF
--- a/web/app/containers/app/container.js
+++ b/web/app/containers/app/container.js
@@ -24,16 +24,16 @@ import NotificationManager from '../../components/notification-manager'
 
 import {requestIdleCallback} from '../../utils/utils'
 
-// These Unwrapped containers are loadable components. They'll only be
+// These containers are loadable components. They'll only be
 // downloaded when we call upon them
 import {
-    UnwrappedCart,
-    UnwrappedCheckoutConfirmation,
-    UnwrappedCheckoutPayment,
-    UnwrappedCheckoutShipping,
-    UnwrappedLogin,
-    UnwrappedProductDetails,
-    UnwrappedProductList,
+    Cart,
+    CheckoutConfirmation,
+    CheckoutPayment,
+    CheckoutShipping,
+    Login,
+    ProductDetails,
+    ProductList,
     Offline
 } from '../templates'
 
@@ -63,25 +63,25 @@ class App extends React.Component {
         // Lazy load other containers when browser is at the end of frame
         // to prevent jank
         requestIdleCallback(() => {
-            UnwrappedCart.preload()
+            Cart.preload()
         })
         requestIdleCallback(() => {
-            UnwrappedCheckoutConfirmation.preload()
+            CheckoutConfirmation.preload()
         })
         requestIdleCallback(() => {
-            UnwrappedCheckoutPayment.preload()
+            CheckoutPayment.preload()
         })
         requestIdleCallback(() => {
-            UnwrappedCheckoutShipping.preload()
+            CheckoutShipping.preload()
         })
         requestIdleCallback(() => {
-            UnwrappedLogin.preload()
+            Login.preload()
         })
         requestIdleCallback(() => {
-            UnwrappedProductDetails.preload()
+            ProductDetails.preload()
         })
         requestIdleCallback(() => {
-            UnwrappedProductList.preload()
+            ProductList.preload()
         })
     }
 

--- a/web/app/containers/app/container.js
+++ b/web/app/containers/app/container.js
@@ -22,19 +22,7 @@ import * as selectors from './selectors'
 
 import NotificationManager from '../../components/notification-manager'
 
-import {requestIdleCallback} from '../../utils/utils'
-
-// These containers are loadable components. They'll only be
-// downloaded when we call upon them
-import {
-    Cart,
-    CheckoutConfirmation,
-    CheckoutPayment,
-    CheckoutShipping,
-    Login,
-    ProductDetails,
-    ProductList
-} from '../templates'
+import {registerPreloadCallbacks} from '../templates'
 
 // Offline support
 import Offline from '../offline/container'
@@ -62,27 +50,7 @@ class App extends React.Component {
 
         // Lazy load other containers when browser is at the end of frame
         // to prevent jank
-        requestIdleCallback(() => {
-            Cart.preload()
-        })
-        requestIdleCallback(() => {
-            CheckoutConfirmation.preload()
-        })
-        requestIdleCallback(() => {
-            CheckoutPayment.preload()
-        })
-        requestIdleCallback(() => {
-            CheckoutShipping.preload()
-        })
-        requestIdleCallback(() => {
-            Login.preload()
-        })
-        requestIdleCallback(() => {
-            ProductDetails.preload()
-        })
-        requestIdleCallback(() => {
-            ProductList.preload()
-        })
+        registerPreloadCallbacks()
     }
 
     render() {

--- a/web/app/containers/app/container.js
+++ b/web/app/containers/app/container.js
@@ -33,11 +33,11 @@ import {
     CheckoutShipping,
     Login,
     ProductDetails,
-    ProductList,
-    Offline
+    ProductList
 } from '../templates'
 
 // Offline support
+import Offline from '../offline/container'
 import OfflineBanner from '../offline/partials/offline-banner'
 import OfflineModal from '../offline/partials/offline-modal'
 

--- a/web/app/containers/cart/container.js
+++ b/web/app/containers/cart/container.js
@@ -1,5 +1,6 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
+import template from '../../template'
 import {createPropsSelector} from 'reselect-immutable-helpers'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
 import classNames from 'classnames'
@@ -117,4 +118,4 @@ const mapStateToProps = createPropsSelector({
     hasItems: getCartHasItems
 })
 
-export default connect(mapStateToProps)(Cart)
+export default template(connect(mapStateToProps)(Cart))

--- a/web/app/containers/checkout-shipping/container.jsx
+++ b/web/app/containers/checkout-shipping/container.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {connect} from 'react-redux'
+import template from '../../template'
 import {createPropsSelector} from 'reselect-immutable-helpers'
 import classNames from 'classnames'
 import {fetchCheckoutShippingData} from '../../integration-manager/checkout/commands'
@@ -50,4 +51,4 @@ const mapStateToProps = createPropsSelector({
     cartURL: getCartURL
 })
 
-export default connect(mapStateToProps)(CheckoutShipping)
+export default template(connect(mapStateToProps)(CheckoutShipping))

--- a/web/app/containers/home/container.jsx
+++ b/web/app/containers/home/container.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import template from '../../template'
 
 import {fetchHomeData} from '../../integration-manager/home/commands'
 
@@ -17,4 +18,4 @@ const Home = () => {
 
 Home.fetcher = (url, routeName, dispatch) => dispatch(fetchHomeData(url, routeName))
 
-export default Home
+export default template(Home)

--- a/web/app/containers/login/container.js
+++ b/web/app/containers/login/container.js
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {withRouter} from 'progressive-web-sdk/dist/routing'
+import template from '../../template'
 
 import {fetchSigninData, fetchRegisterData, navigateToSection} from '../../integration-manager/login/commands'
 
@@ -103,4 +104,4 @@ Login.propTypes = {
     routes: PropTypes.array
 }
 
-export default connect(null, mapDispatchToProps)(withRouter(Login))
+export default template(connect(null, mapDispatchToProps)(withRouter(Login)))

--- a/web/app/containers/login/container.test.js
+++ b/web/app/containers/login/container.test.js
@@ -6,7 +6,7 @@ import React from 'react'
 import * as AstroIntegration from '../../utils/astro-integration'
 
 import ConnectedLogin from './container'
-const Login = ConnectedLogin.WrappedComponent
+const Login = ConnectedLogin.WrappedComponent.WrappedComponent
 
 describe('The Login', () => {
     const originalIsRunningInAstro = AstroIntegration.isRunningInAstro

--- a/web/app/containers/offline/container.jsx
+++ b/web/app/containers/offline/container.jsx
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react'
+import template from '../../template'
 
 import DangerousHTML from 'progressive-web-sdk/dist/components/dangerous-html'
 import Button from 'progressive-web-sdk/dist/components/button'
@@ -33,4 +34,4 @@ Offline.propTypes = {
     reload: PropTypes.func.isRequired
 }
 
-export default Offline
+export default template(Offline)

--- a/web/app/containers/product-details/container.jsx
+++ b/web/app/containers/product-details/container.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import template from '../../template'
 
 import {fetchPdpData} from '../../integration-manager/products/commands'
 
@@ -33,4 +34,4 @@ ProductDetails.propTypes = {
     route: React.PropTypes.object,
 }
 
-export default ProductDetails
+export default template(ProductDetails)

--- a/web/app/containers/product-list/container.js
+++ b/web/app/containers/product-list/container.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import template from '../../template'
 
 import {fetchProductListData} from '../../integration-manager/categories/commands'
 import {isRunningInAstro} from '../../utils/astro-integration'
@@ -19,4 +20,4 @@ const ProductList = () => {
 ProductList.fetcher = (url, routeName, dispatch) => dispatch(fetchProductListData(url, routeName))
 
 
-export default ProductList
+export default template(ProductList)

--- a/web/app/containers/templates.js
+++ b/web/app/containers/templates.js
@@ -5,51 +5,55 @@ import Loadable from 'react-loadable'
 import template from '../template'
 
 // Don't split the Home container out from the main app, so that we can have instant page transitions
-import UnwrappedHome from './home/container'
-import UnwrappedOffline from './offline/container'
+import Home from './home/container'
+import Offline from './offline/container'
 import ContainerPlaceholder from '../components/container-placeholder'
 
-export const UnwrappedCart = Loadable({
-    loader: () => import('./cart/container'),
-    LoadingComponent: ContainerPlaceholder
-})
+// export const UnwrappedCart = Loadable({
+//     loader: () => import('./cart/container'),
+//     LoadingComponent: ContainerPlaceholder
+// })
 
-export const UnwrappedCheckoutConfirmation = Loadable({
-    loader: () => import('./checkout-confirmation/container'),
-    LoadingComponent: ContainerPlaceholder
-})
+// export const UnwrappedCheckoutConfirmation = Loadable({
+//     loader: () => import('./checkout-confirmation/container'),
+//     LoadingComponent: ContainerPlaceholder
+// })
 
-export const UnwrappedCheckoutPayment = Loadable({
-    loader: () => import('./checkout-payment/container'),
-    LoadingComponent: ContainerPlaceholder
-})
+// export const UnwrappedCheckoutPayment = Loadable({
+//     loader: () => import('./checkout-payment/container'),
+//     LoadingComponent: ContainerPlaceholder
+// })
 
-export const UnwrappedCheckoutShipping = Loadable({
-    loader: () => import('./checkout-shipping/container'),
-    LoadingComponent: ContainerPlaceholder
-})
+// export const UnwrappedCheckoutShipping = Loadable({
+//     loader: () => import('./checkout-shipping/container'),
+//     LoadingComponent: ContainerPlaceholder
+// })
 
-export const UnwrappedLogin = Loadable({
-    loader: () => import('./login/container'),
-    LoadingComponent: ContainerPlaceholder
-})
+// export const UnwrappedLogin = Loadable({
+//     loader: () => import('./login/container'),
+//     LoadingComponent: ContainerPlaceholder
+// })
 
-export const UnwrappedProductDetails = Loadable({
+export const ProductDetails = Loadable({
     loader: () => import('./product-details/container'),
     LoadingComponent: ContainerPlaceholder
 })
 
-export const UnwrappedProductList = Loadable({
+export const ProductList = Loadable({
     loader: () => import('./product-list/container'),
     LoadingComponent: ContainerPlaceholder
 })
+
+import UnwrappedCart from './cart/container'
+import UnwrappedCheckoutConfirmation from './checkout-confirmation/container'
+import UnwrappedCheckoutPayment from './checkout-payment/container'
+import UnwrappedCheckoutShipping from './checkout-shipping/container'
+import UnwrappedLogin from './login/container'
 
 export const Cart = template(UnwrappedCart)
 export const CheckoutConfirmation = template(UnwrappedCheckoutConfirmation)
 export const CheckoutPayment = template(UnwrappedCheckoutPayment)
 export const CheckoutShipping = template(UnwrappedCheckoutShipping)
-export const Home = template(UnwrappedHome)
 export const Login = template(UnwrappedLogin)
-export const ProductDetails = template(UnwrappedProductDetails)
-export const ProductList = template(UnwrappedProductList)
-export const Offline = template(UnwrappedOffline)
+
+export {Home, Offline}

--- a/web/app/containers/templates.js
+++ b/web/app/containers/templates.js
@@ -9,30 +9,34 @@ import Home from './home/container'
 import Offline from './offline/container'
 import ContainerPlaceholder from '../components/container-placeholder'
 
-// export const UnwrappedCart = Loadable({
-//     loader: () => import('./cart/container'),
-//     LoadingComponent: ContainerPlaceholder
-// })
+export const Cart = Loadable({
+    loader: () => import('./cart/container'),
+    LoadingComponent: ContainerPlaceholder
+})
 
-// export const UnwrappedCheckoutConfirmation = Loadable({
-//     loader: () => import('./checkout-confirmation/container'),
-//     LoadingComponent: ContainerPlaceholder
-// })
+// These are on the old model and need to be wrapped here
+// rather than in container.js
+export const CheckoutConfirmation = Loadable({
+    loader: () => import('./checkout-confirmation/container')
+        .then((component) => template(component)),
+    LoadingComponent: ContainerPlaceholder
+})
 
-// export const UnwrappedCheckoutPayment = Loadable({
-//     loader: () => import('./checkout-payment/container'),
-//     LoadingComponent: ContainerPlaceholder
-// })
+export const CheckoutPayment = Loadable({
+    loader: () => import('./checkout-payment/container')
+        .then((component) => template(component)),
+    LoadingComponent: ContainerPlaceholder
+})
 
-// export const UnwrappedCheckoutShipping = Loadable({
-//     loader: () => import('./checkout-shipping/container'),
-//     LoadingComponent: ContainerPlaceholder
-// })
+export const CheckoutShipping = Loadable({
+    loader: () => import('./checkout-shipping/container'),
+    LoadingComponent: ContainerPlaceholder
+})
 
-// export const UnwrappedLogin = Loadable({
-//     loader: () => import('./login/container'),
-//     LoadingComponent: ContainerPlaceholder
-// })
+export const Login = Loadable({
+    loader: () => import('./login/container'),
+    LoadingComponent: ContainerPlaceholder
+})
 
 export const ProductDetails = Loadable({
     loader: () => import('./product-details/container'),
@@ -43,17 +47,5 @@ export const ProductList = Loadable({
     loader: () => import('./product-list/container'),
     LoadingComponent: ContainerPlaceholder
 })
-
-import UnwrappedCart from './cart/container'
-import UnwrappedCheckoutConfirmation from './checkout-confirmation/container'
-import UnwrappedCheckoutPayment from './checkout-payment/container'
-import UnwrappedCheckoutShipping from './checkout-shipping/container'
-import UnwrappedLogin from './login/container'
-
-export const Cart = template(UnwrappedCart)
-export const CheckoutConfirmation = template(UnwrappedCheckoutConfirmation)
-export const CheckoutPayment = template(UnwrappedCheckoutPayment)
-export const CheckoutShipping = template(UnwrappedCheckoutShipping)
-export const Login = template(UnwrappedLogin)
 
 export {Home, Offline}

--- a/web/app/containers/templates.js
+++ b/web/app/containers/templates.js
@@ -5,42 +5,39 @@ import Loadable from 'react-loadable'
 import template from '../template'
 
 import ContainerPlaceholder from '../components/container-placeholder'
+import {requestIdleCallback} from '../utils/utils'
 
-export const Cart = Loadable({
-    loader: () => import('./cart/container'),
-    LoadingComponent: ContainerPlaceholder
-})
+const loadableList = []
+const PWALoadable = (loader) => {
+    const loadable = Loadable({
+        loader,
+        LoadingComponent: ContainerPlaceholder
+    })
+    loadableList.push(loadable)
+    return loadable
+}
+
+export const registerPreloadCallbacks = () => {
+    loadableList.forEach((loadable) => {
+        requestIdleCallback(() => loadable.preload())
+    })
+}
+
 
 // These are on the old model and need to be wrapped here
-// rather than in container.js
-export const CheckoutConfirmation = Loadable({
-    loader: () => import('./checkout-confirmation/container')
-        .then((component) => template(component)),
-    LoadingComponent: ContainerPlaceholder
-})
+// rather than in container.js to avoid circular imports
+export const CheckoutConfirmation = PWALoadable(
+    () => import('./checkout-confirmation/container')
+        .then((component) => template(component))
+)
 
-export const CheckoutPayment = Loadable({
-    loader: () => import('./checkout-payment/container')
-        .then((component) => template(component)),
-    LoadingComponent: ContainerPlaceholder
-})
+export const CheckoutPayment = PWALoadable(
+    () => import('./checkout-payment/container')
+        .then((component) => template(component))
+)
 
-export const CheckoutShipping = Loadable({
-    loader: () => import('./checkout-shipping/container'),
-    LoadingComponent: ContainerPlaceholder
-})
-
-export const Login = Loadable({
-    loader: () => import('./login/container'),
-    LoadingComponent: ContainerPlaceholder
-})
-
-export const ProductDetails = Loadable({
-    loader: () => import('./product-details/container'),
-    LoadingComponent: ContainerPlaceholder
-})
-
-export const ProductList = Loadable({
-    loader: () => import('./product-list/container'),
-    LoadingComponent: ContainerPlaceholder
-})
+export const Cart = PWALoadable(() => import('./cart/container'))
+export const CheckoutShipping = PWALoadable(() => import('./checkout-shipping/container'))
+export const Login = PWALoadable(() => import('./login/container'))
+export const ProductDetails = PWALoadable(() => import('./product-details/container'))
+export const ProductList = PWALoadable(() => import('./product-list/container'))

--- a/web/app/containers/templates.js
+++ b/web/app/containers/templates.js
@@ -4,9 +4,6 @@ import Loadable from 'react-loadable'
 
 import template from '../template'
 
-// Don't split the Home container out from the main app, so that we can have instant page transitions
-import Home from './home/container'
-import Offline from './offline/container'
 import ContainerPlaceholder from '../components/container-placeholder'
 
 export const Cart = Loadable({
@@ -47,5 +44,3 @@ export const ProductList = Loadable({
     loader: () => import('./product-list/container'),
     LoadingComponent: ContainerPlaceholder
 })
-
-export {Home, Offline}

--- a/web/app/router.jsx
+++ b/web/app/router.jsx
@@ -6,6 +6,7 @@ import {Provider} from 'react-redux'
 
 // Containers
 import App from './containers/app/container'
+// These templates are code-split out of the main bundle.
 import {Cart, CheckoutConfirmation, CheckoutPayment, CheckoutShipping, Login, ProductList, ProductDetails} from './containers/templates'
 // We build this into the app so we can load the home page right away
 import Home from './containers/home/container'

--- a/web/app/router.jsx
+++ b/web/app/router.jsx
@@ -6,7 +6,9 @@ import {Provider} from 'react-redux'
 
 // Containers
 import App from './containers/app/container'
-import {Cart, CheckoutConfirmation, CheckoutPayment, CheckoutShipping, Home, Login, ProductList, ProductDetails} from './containers/templates'
+import {Cart, CheckoutConfirmation, CheckoutPayment, CheckoutShipping, Login, ProductList, ProductDetails} from './containers/templates'
+// We build this into the app so we can load the home page right away
+import Home from './containers/home/container'
 import CheckoutHeader from './containers/checkout-header/container'
 import CheckoutFooter from './containers/checkout-footer/container'
 


### PR DESCRIPTION
By separating the Template HoC from the actual template components, the React Loadable work made the `fetcher` functions not work. This PR rearranges things so that they will work again. 

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-56

## Changes
- Wrap the template components in their own `container.js`, as long as they've been converted to the Integration Manager from the old `fetchPage` action. (the IM changes broke the circular dependency)
- Write a wrapper component for Loadable to simplify `templates.jsx` and the lazy-load of the templates in the App component.

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- See that all of the non-Home templates work again.
