### PR TITLE
move product details accordion and open by default

### DIFF
--- a/web/app/containers/product-details/container.js
+++ b/web/app/containers/product-details/container.js
@@ -12,8 +12,8 @@ const ProductDetails = ({route: {routeName}}) => {
         <div className="t-product-details">
             <ProductDetailsHeading isInCheckout={routeName === 'cartEditPage'} />
             <ProductDetailsCarousel />
-            <ProductDetailsDescription />
             <ProductDetailsAddToCart />
+            <ProductDetailsDescription />
             <ProductDetailsItemAddedModal />
             <div className="u-padding-md u-bg-color-neutral-10">
                 <ProductNearestStores title="The Product is sold in the store" viewAllStoresText="Check all stores" class="u-margin-all" />

--- a/web/app/containers/product-details/partials/product-details-description.jsx
+++ b/web/app/containers/product-details/partials/product-details-description.jsx
@@ -6,7 +6,7 @@ import * as selectors from '../selectors'
 import {Accordion, AccordionItem} from 'progressive-web-sdk/dist/components/accordion'
 
 const ProductDetailsDescription = ({description}) => (
-    <Accordion className="t-product-details__description">
+    <Accordion className="t-product-details__description" initialOpenItems={[0]}>
         <AccordionItem header="Product Description" closeIconName="close" openIconName="plus">
             <p>{description}</p>
         </AccordionItem>


### PR DESCRIPTION
rearrange content so product description is placed below the buying options

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1334

## Changes
- move product detail accordion
- make it open by default

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- go to PDP
