### PR TITLE
Move product selectors out of the product details branch

### DIFF
--- a/web/app/containers/product-details/actions.js
+++ b/web/app/containers/product-details/actions.js
@@ -3,8 +3,8 @@ import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
 import {SubmissionError} from 'redux-form'
 import {createPropsSelector} from 'reselect-immutable-helpers'
 
-import * as selectors from './selectors'
-import * as appSelectors from '../app/selectors'
+import {getItemQuantity, getAddToCartFormValues} from './selectors'
+import {getCurrentPathKey, getCartURL} from '../app/selectors'
 import {getProductVariants, getProductVariationCategories, getProductVariationCategoryIds} from '../../store/products/selectors'
 
 import {addToCart} from '../../integration-manager/cart/commands'
@@ -18,7 +18,7 @@ import {isRunningInAstro, trigger} from '../../utils/astro-integration'
 export const receiveNewItemQuantity = createAction('Set item quantity')
 export const setItemQuantity = (quantity) => (dispatch, getStore) => {
     dispatch(receiveNewItemQuantity({
-        [appSelectors.getCurrentPathKey(getStore())]: {
+        [getCurrentPathKey(getStore())]: {
             itemQuantity: quantity
         }
     }))
@@ -34,13 +34,13 @@ export const goToCheckout = () => (dispatch, getState) => {
         // otherwise, navigating is taken care of by the button press
         trigger('open:cart-modal')
     } else {
-        browserHistory.push(appSelectors.getCartURL(getState()))
+        browserHistory.push(getCartURL(getState()))
     }
 }
 
 const submitCartFormSelector = createPropsSelector({
-    key: appSelectors.getCurrentPathKey,
-    qty: selectors.getItemQuantity,
+    key: getCurrentPathKey,
+    qty: getItemQuantity,
     variations: getProductVariationCategories
 })
 
@@ -74,7 +74,7 @@ export const submitCartForm = (formValues) => (dispatch, getStore) => {
 }
 
 const variationBlurSelector = createPropsSelector({
-    variationSelections: selectors.getAddToCartFormValues,
+    variationSelections: getAddToCartFormValues,
     categoryIds: getProductVariationCategoryIds,
     variants: getProductVariants
 })

--- a/web/app/containers/product-details/actions.js
+++ b/web/app/containers/product-details/actions.js
@@ -5,6 +5,7 @@ import {createPropsSelector} from 'reselect-immutable-helpers'
 
 import * as selectors from './selectors'
 import * as appSelectors from '../app/selectors'
+import {getProductVariants, getProductVariationCategories, getProductVariationCategoryIds} from '../../store/products/selectors'
 
 import {addToCart} from '../../integration-manager/cart/commands'
 import {getProductVariantData} from '../../integration-manager/products/commands'
@@ -40,7 +41,7 @@ export const goToCheckout = () => (dispatch, getState) => {
 const submitCartFormSelector = createPropsSelector({
     key: appSelectors.getCurrentPathKey,
     qty: selectors.getItemQuantity,
-    variations: selectors.getProductVariationCategories
+    variations: getProductVariationCategories
 })
 
 export const submitCartForm = (formValues) => (dispatch, getStore) => {
@@ -74,8 +75,8 @@ export const submitCartForm = (formValues) => (dispatch, getStore) => {
 
 const variationBlurSelector = createPropsSelector({
     variationSelections: selectors.getAddToCartFormValues,
-    categoryIds: selectors.getProductVariationCategoryIds,
-    variants: selectors.getProductVariants
+    categoryIds: getProductVariationCategoryIds,
+    variants: getProductVariants
 })
 
 export const onVariationBlur = () => (dispatch, getStore) => {

--- a/web/app/containers/product-details/partials/product-details-add-to-cart.jsx
+++ b/web/app/containers/product-details/partials/product-details-add-to-cart.jsx
@@ -3,6 +3,7 @@ import {connect} from 'react-redux'
 import * as ReduxForm from 'redux-form'
 import {createPropsSelector} from 'reselect-immutable-helpers'
 import * as selectors from '../selectors'
+import {getProductInitialValues} from '../../../store/products/selectors'
 import * as actions from '../actions'
 
 import ProductDetailsVariations from './product-details-variations'
@@ -65,7 +66,7 @@ const mapStateToProps = createPropsSelector({
     ctaText: selectors.getCTAText,
     quantity: selectors.getItemQuantity,
     disabled: selectors.getAddToCartDisabled,
-    initialValues: selectors.getProductInitialValues
+    initialValues: getProductInitialValues
 })
 
 const mapDispatchToProps = {

--- a/web/app/containers/product-details/partials/product-details-carousel.jsx
+++ b/web/app/containers/product-details/partials/product-details-carousel.jsx
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {createPropsSelector} from 'reselect-immutable-helpers'
 import * as selectors from '../selectors'
+import {getProductImages} from '../../../store/products/selectors'
 import classNames from 'classnames'
 
 import Carousel from 'progressive-web-sdk/dist/components/carousel'
@@ -68,7 +69,7 @@ ProductDetailsCarousel.propTypes = {
 
 const mapStateToProps = createPropsSelector({
     contentsLoaded: selectors.getProductDetailsContentsLoaded,
-    images: selectors.getProductImages
+    images: getProductImages
 })
 
 export default connect(mapStateToProps)(ProductDetailsCarousel)

--- a/web/app/containers/product-details/partials/product-details-description.jsx
+++ b/web/app/containers/product-details/partials/product-details-description.jsx
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {createPropsSelector} from 'reselect-immutable-helpers'
-import * as selectors from '../selectors'
+import {getProductDescription} from '../../../store/products/selectors'
 
 import {Accordion, AccordionItem} from 'progressive-web-sdk/dist/components/accordion'
 
@@ -18,7 +18,7 @@ ProductDetailsDescription.propTypes = {
 }
 
 const mapStateToProps = createPropsSelector({
-    description: selectors.getProductDescription
+    description: getProductDescription
 })
 
 export default connect(mapStateToProps)(ProductDetailsDescription)

--- a/web/app/containers/product-details/partials/product-details-heading.jsx
+++ b/web/app/containers/product-details/partials/product-details-heading.jsx
@@ -3,6 +3,7 @@ import {connect} from 'react-redux'
 import * as selectors from '../selectors'
 import {createPropsSelector} from 'reselect-immutable-helpers'
 import {getCartURL} from '../../app/selectors'
+import {getProductTitle, getProductPrice} from '../../../store/products/selectors'
 
 import SkeletonBlock from 'progressive-web-sdk/dist/components/skeleton-block'
 import Breadcrumbs from 'progressive-web-sdk/dist/components/breadcrumbs'
@@ -42,8 +43,8 @@ ProductDetailsHeading.propTypes = {
 const mapStateToProps = createPropsSelector({
     breadcrumbs: selectors.getProductDetailsBreadcrumbs,
     cartURL: getCartURL,
-    title: selectors.getProductTitle,
-    price: selectors.getProductPrice
+    title: getProductTitle,
+    price: getProductPrice
 })
 
 export default connect(mapStateToProps)(ProductDetailsHeading)

--- a/web/app/containers/product-details/partials/product-details-item-added-modal.jsx
+++ b/web/app/containers/product-details/partials/product-details-item-added-modal.jsx
@@ -4,6 +4,7 @@ import {createPropsSelector} from 'reselect-immutable-helpers'
 import * as selectors from '../selectors'
 import {stripEvent} from '../../../utils/utils'
 import {isModalOpen} from 'progressive-web-sdk/dist/store/modals/selectors'
+import {getProductThumbnail, getProductTitle, getProductPrice} from '../../../store/products/selectors'
 import * as productDetailsActions from '../actions'
 import {PRODUCT_DETAILS_ITEM_ADDED_MODAL} from '../constants'
 import {closeModal} from 'progressive-web-sdk/dist/store/modals/actions'
@@ -74,11 +75,11 @@ ProductDetailsItemAddedModal.propTypes = {
 }
 
 const mapStateToProps = createPropsSelector({
-    thumbnail: selectors.getProductThumbnail,
+    thumbnail: getProductThumbnail,
     open: isModalOpen(PRODUCT_DETAILS_ITEM_ADDED_MODAL),
     quantity: selectors.getItemQuantity,
-    title: selectors.getProductTitle,
-    price: selectors.getProductPrice
+    title: getProductTitle,
+    price: getProductPrice
 })
 
 const mapDispatchToProps = {

--- a/web/app/containers/product-details/partials/product-details-variations.jsx
+++ b/web/app/containers/product-details/partials/product-details-variations.jsx
@@ -2,7 +2,7 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import * as ReduxForm from 'redux-form'
 import {createPropsSelector} from 'reselect-immutable-helpers'
-import {getProductVariationCategories} from '../selectors'
+import {getProductVariationCategories} from '../../../store/products/selectors'
 import {onVariationBlur} from '../actions'
 
 import Field from 'progressive-web-sdk/dist/components/field'

--- a/web/app/containers/product-details/selectors.js
+++ b/web/app/containers/product-details/selectors.js
@@ -1,7 +1,7 @@
 import {createSelector} from 'reselect'
 import Immutable from 'immutable'
 import {createGetSelector, createHasSelector} from 'reselect-immutable-helpers'
-import {getUi, getProducts} from '../../store/selectors'
+import {getUi} from '../../store/selectors'
 import * as appSelectors from '../app/selectors'
 import {getFormValues} from '../../store/form/selectors'
 
@@ -28,12 +28,6 @@ export const getProductDetailsContentsLoaded = createHasSelector(
     appSelectors.getCurrentPathKey
 )
 
-export const getSelectedProduct = createGetSelector(
-    getProducts,
-    appSelectors.getCurrentPathKey,
-    Immutable.Map()
-)
-
 export const getAddToCartInProgress = createGetSelector(getProductDetails, 'addToCartInProgress', false)
 export const getAddToCartDisabled = createSelector(
     getProductDetailsContentsLoaded,
@@ -49,23 +43,5 @@ export const getProductDetailsBreadcrumbs = createGetSelector(
     'breadcrumbs',
     PLACEHOLDER_BREADCRUMBS
 )
-export const getProductTitle = createGetSelector(getSelectedProduct, 'title')
-export const getProductPrice = createGetSelector(getSelectedProduct, 'price')
-export const getProductDescription = createGetSelector(getSelectedProduct, 'description')
-export const getProductImages = createGetSelector(getSelectedProduct, 'images', Immutable.List())
-export const getProductThumbnail = createGetSelector(getSelectedProduct, 'thumbnail', Immutable.Map())
-
-export const getProductVariationCategories = createGetSelector(getSelectedProduct, 'variationCategories', Immutable.List())
-export const getProductVariationCategoryIds = createSelector(
-    getProductVariationCategories,
-    (categories) => categories.map((category) => category.get('id'))
-)
-export const getProductVariants = createGetSelector(getSelectedProduct, 'variants')
-export const getProductInitialValues = createGetSelector(getSelectedProduct, 'initialValues')
 
 export const getAddToCartFormValues = getFormValues('product-add-to-cart')
-// NOTE: These get-something-ByPathKey selectors should only be used within actions/commands
-// Using them within a component will break the performance optimizations selectors normally give us
-export const getProductDetailsByPathKey = (pathKey) => createGetSelector(getProducts, pathKey, Immutable.Map())
-export const getProductThumbnailByPathKey = (pathKey) => createGetSelector(getProductDetailsByPathKey(pathKey), 'thumbnail', Immutable.Map())
-export const getProductThumbnailSrcByPathKey = (pathKey) => createGetSelector(getProductThumbnailByPathKey(pathKey), 'img')

--- a/web/app/integration-manager/_demandware-connector/cart/utils.js
+++ b/web/app/integration-manager/_demandware-connector/cart/utils.js
@@ -1,6 +1,6 @@
 import {makeDemandwareRequest, getBasketID, storeBasketID} from '../utils'
 import {receiveCartContents} from '../../cart/responses'
-import {getProductThumbnailSrcByPathKey} from '../../../containers/product-details/selectors'
+import {getProductThumbnailSrcByPathKey} from '../../../store/products/selectors'
 import {parseBasketContents, getProductHref} from '../parsers'
 import {API_END_POINT_URL} from '../constants'
 

--- a/web/app/store/products/selectors.js
+++ b/web/app/store/products/selectors.js
@@ -1,0 +1,29 @@
+import {createSelector} from 'reselect'
+import Immutable from 'immutable'
+import {createGetSelector} from 'reselect-immutable-helpers'
+
+import {getProducts} from '../selectors'
+import {getCurrentPathKey} from '../../containers/app/selectors'
+
+export const getSelectedProduct = createGetSelector(getProducts, getCurrentPathKey, Immutable.Map())
+
+export const getProductTitle = createGetSelector(getSelectedProduct, 'title')
+export const getProductPrice = createGetSelector(getSelectedProduct, 'price')
+export const getProductDescription = createGetSelector(getSelectedProduct, 'description')
+export const getProductImages = createGetSelector(getSelectedProduct, 'images', Immutable.List())
+export const getProductThumbnail = createGetSelector(getSelectedProduct, 'thumbnail', Immutable.Map())
+
+export const getProductVariationCategories = createGetSelector(getSelectedProduct, 'variationCategories', Immutable.List())
+
+export const getProductVariationCategoryIds = createSelector(
+    getProductVariationCategories,
+    (categories) => categories.map((category) => category.get('id'))
+)
+export const getProductVariants = createGetSelector(getSelectedProduct, 'variants')
+export const getProductInitialValues = createGetSelector(getSelectedProduct, 'initialValues')
+
+// NOTE: These get-something-ByPathKey selectors should only be used within actions/commands
+// Using them within a component will break the performance optimizations selectors normally give us
+export const getProductDetailsByPathKey = (pathKey) => createGetSelector(getProducts, pathKey, Immutable.Map())
+export const getProductThumbnailByPathKey = (pathKey) => createGetSelector(getProductDetailsByPathKey(pathKey), 'thumbnail', Immutable.Map())
+export const getProductThumbnailSrcByPathKey = (pathKey) => createGetSelector(getProductThumbnailByPathKey(pathKey), 'img')


### PR DESCRIPTION
This PR separates the selectors for the product information in the store from the selectors for the product details UI data. 

 **JIRA**: N/A (but found while working on https://mobify.atlassian.net/browse/WEBDATA-10)

## Changes
- Move product selectors to `app/store/products/selectors.js` so they aren't so tied to the ProductDetails container.

## How to test-drive this PR
- Preview and see that nothing has changed.