### PR TITLE
Pull out test-server into its own npm script

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -122,6 +122,7 @@
     "test:pwa-prod": "./scripts/lighthouse-prod.sh",
     "test:pwa-ci": "./scripts/lighthouse-ci.sh",
     "test:pwa-local": "./scripts/lighthouse-local.sh",
+    "test:server": "./scripts/test-server.sh",
     "test:watch": "npm test -- --watch",
     "prod:build": "bash ./scripts/build.sh",
     "update-loader-routes": "sdk-get-routes"

--- a/web/scripts/lighthouse-ci.sh
+++ b/web/scripts/lighthouse-ci.sh
@@ -28,8 +28,7 @@ certutil -d $HOME/.pki/nssdb -N --empty-password
 certutil -d sql:$HOME/.pki/nssdb -A -t "P,," -n lighthouse/server.pem -i lighthouse/server.pem
 
 npm run prod:build
-http-server --ssl --cors --p=8443 \
-	--key lighthouse/server.pem --cert lighthouse/server.pem build &
+npm run test:server &
 
 sleep 5
 lighthouse \

--- a/web/scripts/test-server.sh
+++ b/web/scripts/test-server.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Start test server on build folder
+
+http-server --ssl --cors --p=8443 \
+	--key lighthouse/server.pem --cert lighthouse/server.pem build

--- a/web/tests/system/smoke-test.sh
+++ b/web/tests/system/smoke-test.sh
@@ -24,8 +24,7 @@ if [ "$CURRENT_BRANCH" != "master" ]; then
     trap 'kill $(jobs -p)' EXIT > /dev/null 2>&1
     export ACTIVE_PROFILE=local
     npm run prod:build
-    http-server --ssl --cors --p=8443 \
-      --key lighthouse/server.pem --cert lighthouse/server.pem build > /dev/null 2>&1 &
+    npm run test:server > /dev/null 2>&1 &
 else
     echo "Running tests against production"
     export ACTIVE_PROFILE=production


### PR DESCRIPTION
We start a `http-server` to serve up a production build in both the end-to-end tests and the Lighthouse CI script. Let's make it a npm script.

 **Linked PRs**: Feedback from https://github.com/mobify/platform-scaffold/pull/521

## Changes
- Adds `npm run test-server` to serve a production build. 

## How to test-drive this PR
- `npm run prod:build`
- `npm run test:server`
- Verify that a local server is started and is serving the build on HTTPS
- `npm run smoke-test` and `npm run pwa-ci` should work as before
