### PR TITLE
Verify input types

### DIFF
--- a/web/tests/system/page-objects/checkout.js
+++ b/web/tests/system/page-objects/checkout.js
@@ -2,7 +2,7 @@ const selectors = {
     checkoutTemplateIdentifier: '.t-checkout-shipping.t--loaded',
 
     registeredEmail: 'input[name="username"]',
-    registeredPassword: 'input[name="password"]',
+    registeredPassword: 'input[name="password"][type="password"]',
     signIn: '.qa-checkout__sign-in',
 
     // Shipping info

--- a/web/tests/system/page-objects/home.js
+++ b/web/tests/system/page-objects/home.js
@@ -7,7 +7,7 @@ const selectors = {
     productListItem(index) {
         return `.t-home__category .t-home__category-section:nth-child(${index}) .pw--is-loaded`
     },
-    email: '.pw-field__input input[type="email"]'
+    email: '.pw-field__input'
 }
 
 const Home = function(browser) {

--- a/web/tests/system/page-objects/home.js
+++ b/web/tests/system/page-objects/home.js
@@ -6,7 +6,8 @@ const selectors = {
     skipToFooter: '.pw-skip-links__anchor:last-of-type',
     productListItem(index) {
         return `.t-home__category .t-home__category-section:nth-child(${index}) .pw--is-loaded`
-    }
+    },
+    email: '.pw-field__input input[type="email"]'
 }
 
 const Home = function(browser) {

--- a/web/tests/system/workflows/guest-checkout.js
+++ b/web/tests/system/workflows/guest-checkout.js
@@ -73,7 +73,6 @@ export default {
             .assert.visible(productDetails.selectors.itemAdded)
     },
 
-
     'Checkout - Guest - Navigate from ProductDetails to Cart': (browser) => {
         productDetails.navigateToCart()
         browser

--- a/web/tests/system/workflows/home-example.js
+++ b/web/tests/system/workflows/home-example.js
@@ -42,7 +42,7 @@ export default {
 
     'Email field has email input type': (browser) => {
         browser
-            .waitForElementVisible(home.selectors.email)
-            .assert.visible(home.selectors.email)
+            .waitForElementVisible(`${home.selectors.email} [type="email"]`)
+            .assert.visible(`${home.selectors.email} [type="email"]`)
     },
 }

--- a/web/tests/system/workflows/home-example.js
+++ b/web/tests/system/workflows/home-example.js
@@ -38,5 +38,11 @@ export default {
             .assert.attributeContains(home.selectors.skipToMain, 'href', skipLinkTargets.main)
             .assert.attributeContains(home.selectors.skipToNav, 'href', skipLinkTargets.nav)
             .assert.attributeContains(home.selectors.skipToFooter, 'href', skipLinkTargets.footer)
-    }
+    },
+
+    'Email field has email input type': (browser) => {
+        browser
+            .waitForElementVisible(home.selectors.email)
+            .assert.visible(home.selectors.email)
+    },
 }

--- a/web/tests/system/workflows/registered-checkout.js
+++ b/web/tests/system/workflows/registered-checkout.js
@@ -81,7 +81,7 @@ export default {
             .waitForElementVisible(checkout.selectors.checkoutTemplateIdentifier)
             .assert.visible(checkout.selectors.checkoutTemplateIdentifier)
             // Email field should have email input type
-            .waitForElementVisible(checkout.selectors.registeredEmail + '[type="email"]')
+            .waitForElementVisible(`${checkout.selectors.registeredEmail} + [type="email"]`)
     },
 
     'Checkout - Registered - Continue to Registered Checkout': (browser) => {
@@ -95,7 +95,7 @@ export default {
         checkout.fillShippingInfo()
         browser
             // Phone field should have numeric input type
-            .waitForElementVisible(checkout.selectors.phone + '[type="tel"]')
+            .waitForElementVisible(`${checkout.selectors.phone} + [type="tel"]`)
             .waitForElementVisible(checkout.selectors.lastShippingInfo)
     },
 

--- a/web/tests/system/workflows/registered-checkout.js
+++ b/web/tests/system/workflows/registered-checkout.js
@@ -80,6 +80,8 @@ export default {
         browser
             .waitForElementVisible(checkout.selectors.checkoutTemplateIdentifier)
             .assert.visible(checkout.selectors.checkoutTemplateIdentifier)
+            // Email field should have email input type
+            .waitForElementVisible(checkout.selectors.registeredEmail + '[type="email"]')
     },
 
     'Checkout - Registered - Continue to Registered Checkout': (browser) => {
@@ -91,7 +93,10 @@ export default {
 
     'Checkout - Registered - Fill out Shipping Info form': (browser) => {
         checkout.fillShippingInfo()
-        browser.waitForElementVisible(checkout.selectors.lastShippingInfo)
+        browser
+            // Phone field should have numeric input type
+            .waitForElementVisible(checkout.selectors.phone + '[type="tel"]')
+            .waitForElementVisible(checkout.selectors.lastShippingInfo)
     },
 
     'Checkout - Registered - Fill out Registered Checkout Payment Details form': () => {

--- a/web/tests/system/workflows/registered-checkout.js
+++ b/web/tests/system/workflows/registered-checkout.js
@@ -81,7 +81,7 @@ export default {
             .waitForElementVisible(checkout.selectors.checkoutTemplateIdentifier)
             .assert.visible(checkout.selectors.checkoutTemplateIdentifier)
             // Email field should have email input type
-            .waitForElementVisible(`${checkout.selectors.registeredEmail} + [type="email"]`)
+            .waitForElementVisible(`${checkout.selectors.registeredEmail}[type="email"]`)
     },
 
     'Checkout - Registered - Continue to Registered Checkout': (browser) => {
@@ -95,7 +95,7 @@ export default {
         checkout.fillShippingInfo()
         browser
             // Phone field should have numeric input type
-            .waitForElementVisible(`${checkout.selectors.phone} + [type="tel"]`)
+            .waitForElementVisible(`${checkout.selectors.phone}[type="tel"]`)
             .waitForElementVisible(checkout.selectors.lastShippingInfo)
     },
 


### PR DESCRIPTION
Verify email and numeric input types on certain fields

## Changes
- Verify that email field on homepage is email type
- Verify that email field for log in (on checkout) is email type
- Verify that phone number field is numeric type
- Verify that password field is password type

## How to test-drive this PR
- `npm run smoke-test`
- or Rebuild on CI: https://circleci.com/gh/mobify/platform-scaffold/tree/verify-input-types
