### PR TITLE
Fix `import()` errors during `npm run build:prod`

### DIFF
--- a/web/.babelrc
+++ b/web/.babelrc
@@ -4,6 +4,7 @@
     "react"
   ],
   "plugins": [
+    "dynamic-import-node",
     "transform-object-rest-spread",
     "transform-object-assign",
     ["transform-runtime", {
@@ -14,7 +15,6 @@
   "env": {
     "test": {
       "plugins": [
-        "dynamic-import-node"
       ]
     }
   }


### PR DESCRIPTION
Since we started using the dynamic `import()` function in bundle splitting, I think we've had a broken build (as shown below).  This PR fixes this by properly activating the `dynamic-import-node` Babel plugin for all uses instead of just for tests.

See https://github.com/airbnb/babel-plugin-dynamic-import-node

```sh
    ERROR in ./app/containers/templates.js
    Module build failed: ReferenceError: /Users/jeremy/Development/platform-scaffold/web/app/containers/templates.js: unknown node of type "Import" with constructor "Node"
        at Generator.print (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:279:13)
        at Generator.CallExpression (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/generators/expressions.js:122:8)
        at /Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:298:23
        at Buffer.withSource (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/buffer.js:151:5)
        at Generator.withSource (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:189:15)
        at Generator.print (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:297:10)
        at Generator.ReturnStatement (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/generators/statements.js:160:12)
        at /Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:298:23
        at Buffer.withSource (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/buffer.js:151:5)
        at Generator.withSource (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:189:15)
        at Generator.print (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:297:10)
        at Generator.printJoin (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:368:12)
        at Generator.printSequence (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:422:17)
        at Generator.BlockStatement (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/generators/base.js:40:10)
        at /Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:298:23
        at Buffer.withSource (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/buffer.js:151:5)
        at Generator.withSource (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:189:15)
        at Generator.print (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:297:10)
        at Generator.FunctionExpression (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/generators/methods.js:84:8)
        at /Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:298:23
        at Buffer.withSource (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/buffer.js:151:5)
        at Generator.withSource (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:189:15)
        at Generator.print (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:297:10)
        at Generator.ObjectProperty (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/generators/types.js:92:8)
        at /Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:298:23
        at Buffer.withSource (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/buffer.js:151:5)
        at Generator.withSource (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:189:15)
        at Generator.print (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:297:10)
        at Generator.printJoin (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:368:12)
        at Generator.printList (/Users/jeremy/Development/platform-scaffold/web/node_modules/babel-generator/lib/printer.js:432:17)
     @ ./app/router.jsx 19:17-50
     @ ./app/main.jsx
     @ multi ./app/main.jsx
```

 **JIRA**: N/A
 **Linked PRs**: N/A

## Changes
- Move the `dynamic-import-node` plugin into the general `.babelrc` plugin area instead of just being applied to tests.

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Run `npm run build:prod`
