### PR TITLE
[Integration Manager] Split out category selectors

### DIFF
--- a/web/app/containers/product-list/partials/product-list-contents.jsx
+++ b/web/app/containers/product-list/partials/product-list-contents.jsx
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {createPropsSelector} from 'reselect-immutable-helpers'
+import {getCategoryItemCount} from '../../../store/categories/selectors'
 import * as selectors from '../selectors'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
 import {PRODUCT_LIST_FILTER_MODAL} from '../constants'
@@ -142,16 +143,14 @@ ProductListContents.propTypes = {
     contentsLoaded: PropTypes.bool,
     numItems: PropTypes.number,
     openModal: PropTypes.func,
-    sort: PropTypes.object,
     sortChange: PropTypes.func
 }
 
 const mapStateToProps = createPropsSelector({
     contentsLoaded: selectors.getProductListContentsLoaded,
-    numItems: selectors.getNumItems,
+    numItems: getCategoryItemCount,
     activeFilters: selectors.getActiveFilters,
-    products: selectors.getFilteredAndSortedListProducts,
-    sort: selectors.getSort
+    products: selectors.getFilteredAndSortedListProducts
 })
 
 const mapDispatchToProps = {

--- a/web/app/containers/product-list/partials/product-list-header.jsx
+++ b/web/app/containers/product-list/partials/product-list-header.jsx
@@ -1,7 +1,8 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {createPropsSelector} from 'reselect-immutable-helpers'
-import * as selectors from '../selectors'
+import {getCategoryTitle, getCategoryParentTitle, getCategoryParentHref} from '../../../store/categories/selectors'
+import {getProductListContentsLoaded} from '../selectors'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
 
 import Link from 'progressive-web-sdk/dist/components/link'
@@ -48,10 +49,10 @@ ProductListHeader.propTypes = {
 }
 
 const mapStateToProps = createPropsSelector({
-    contentsLoaded: selectors.getProductListContentsLoaded,
-    parentHref: selectors.getProductListParentHref,
-    parentName: selectors.getProductListParentName,
-    title: selectors.getProductListTitle
+    contentsLoaded: getProductListContentsLoaded,
+    parentHref: getCategoryParentHref,
+    parentName: getCategoryParentTitle,
+    title: getCategoryTitle
 })
 
 export default connect(mapStateToProps)(ProductListHeader)

--- a/web/app/containers/product-list/selectors.js
+++ b/web/app/containers/product-list/selectors.js
@@ -1,13 +1,11 @@
 import Immutable from 'immutable'
 import {createSelector} from 'reselect'
 import {createGetSelector, createHasSelector} from 'reselect-immutable-helpers'
-import {getUi, getCategories, getProducts} from '../../store/selectors'
+import {getUi, getCategories} from '../../store/selectors'
+import {getSelectedCategory, getCategoryProducts} from '../../store/categories/selectors'
 import {getCurrentPathKey} from '../app/selectors'
-import {PLACEHOLDER} from '../app/constants'
 import {byFilters} from '../../utils/filter-utils'
 import {sortLib} from '../../utils/sort-utils'
-
-const PLACEHOLDER_URLS = Immutable.List(new Array(5).fill(PLACEHOLDER))
 
 export const getProductList = createSelector(getUi, ({productList}) => productList)
 
@@ -19,29 +17,9 @@ export const getCurrentProductList = createGetSelector(
 
 export const getCurrentSort = createGetSelector(getCurrentProductList, 'sort')
 
-export const getSelectedCategory = createGetSelector(
-    getCategories,
-    getCurrentPathKey,
-    Immutable.Map()
-)
-
 export const getProductListContentsLoaded = createHasSelector(
     getCategories,
     getCurrentPathKey
-)
-
-export const getProductPaths = createGetSelector(getSelectedCategory, 'products', PLACEHOLDER_URLS)
-export const getNumItems = createGetSelector(getSelectedCategory, 'itemCount')
-export const getProductListTitle = createGetSelector(getSelectedCategory, 'title')
-export const getProductListParentHref = createGetSelector(getSelectedCategory, 'parentHref', '/')
-export const getProductListParentName = createGetSelector(getSelectedCategory, 'parentName', 'Home')
-
-export const getSort = createGetSelector(getSelectedCategory, 'sort', Immutable.Map())
-
-export const getProductListProducts = createSelector(
-    getProducts,
-    getProductPaths,
-    (products, productUrls) => productUrls.map((path) => products.get(path))
 )
 
 export const getFilters = createGetSelector(getSelectedCategory, 'filters', Immutable.List())
@@ -54,7 +32,7 @@ export const getActiveFilters = createSelector(
     )
 )
 export const getFilteredProductListProducts = createSelector(
-    getProductListProducts,
+    getCategoryProducts,
     getActiveFilters,
     (products, filters) => products.filter(byFilters(filters.toJS()))
 )

--- a/web/app/store/categories/actions.js
+++ b/web/app/store/categories/actions.js
@@ -1,6 +1,6 @@
 import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
 import {getCurrentPathKey} from '../../containers/app/selectors'
-import {getSelectedCategory} from '../../containers/product-list/selectors'
+import {getSelectedCategory} from './selectors'
 
 export const changeFilter = createAction('Change Filter')
 

--- a/web/app/store/categories/selectors.js
+++ b/web/app/store/categories/selectors.js
@@ -1,0 +1,47 @@
+import Immutable from 'immutable'
+import {createSelector} from 'reselect'
+import {createGetSelector} from 'reselect-immutable-helpers'
+import {getCategories, getProducts} from '../selectors'
+import {getCurrentPathKey} from '../../containers/app/selectors'
+import {PLACEHOLDER} from '../../containers/app/constants'
+
+export const getSelectedCategory = createGetSelector(
+    getCategories,
+    getCurrentPathKey,
+    Immutable.Map()
+)
+
+const PLACEHOLDER_URLS = Immutable.List(new Array(5).fill(PLACEHOLDER))
+
+export const getCategoryProductPaths = createGetSelector(getSelectedCategory, 'products', PLACEHOLDER_URLS)
+export const getCategoryItemCount = createGetSelector(getSelectedCategory, 'itemCount')
+export const getCategoryTitle = createGetSelector(getSelectedCategory, 'title')
+export const getCategoryParentID = createGetSelector(getSelectedCategory, 'parentId', null)
+
+export const getCategoryParent = createSelector(
+    getCategories,
+    getCategoryParentID,
+    (categories, parentId) => {
+        return parentId
+            ? categories.find((category) => category.get('id') === parentId)
+            : Immutable.Map()
+    }
+)
+
+export const getCategoryParentTitle = createGetSelector(
+    getCategoryParent,
+    'title',
+    'Home'
+)
+
+export const getCategoryParentHref = createGetSelector(
+    getCategoryParent,
+    'href',
+    '/'
+)
+
+export const getCategoryProducts = createSelector(
+    getProducts,
+    getCategoryProductPaths,
+    (products, productUrls) => productUrls.map((path) => products.get(path))
+)


### PR DESCRIPTION
This PR moves the selectors related to the `categories` branch of the store into the `store` directory tree where they belong, and rewrites the other code to match. It also uses the new method of getting the parent category link (following the schema refactor)

 **JIRA**: N/A

## Changes
- Split out and rename category selectors
- Edit the PLP code to use the new selectors

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- See that everything still operates on the PLP
