### PR TITLE
Fix - PDP Product Variant selection requires two clicks

### DIFF
--- a/web/app/containers/product-details/actions.js
+++ b/web/app/containers/product-details/actions.js
@@ -73,18 +73,18 @@ export const submitCartForm = (formValues) => (dispatch, getStore) => {
         .then(() => dispatch(addToCartComplete()))
 }
 
-const variationBlurSelector = createPropsSelector({
+const variationChangeSelector = createPropsSelector({
     variationSelections: getAddToCartFormValues,
     categoryIds: getProductVariationCategoryIds,
     variants: getProductVariants
 })
 
-export const onVariationBlur = () => (dispatch, getStore) => {
+export const onVariationChange = () => (dispatch, getStore) => {
     const {
         variationSelections,
         categoryIds,
         variants
-    } = variationBlurSelector(getStore())
+    } = variationChangeSelector(getStore())
 
     return dispatch(getProductVariantData(variationSelections, variants, categoryIds))
 }

--- a/web/app/containers/product-details/partials/product-details-variations.jsx
+++ b/web/app/containers/product-details/partials/product-details-variations.jsx
@@ -3,11 +3,11 @@ import {connect} from 'react-redux'
 import * as ReduxForm from 'redux-form'
 import {createPropsSelector} from 'reselect-immutable-helpers'
 import {getProductVariationCategories} from '../../../store/products/selectors'
-import {onVariationBlur} from '../actions'
+import {onVariationChange} from '../actions'
 
 import Field from 'progressive-web-sdk/dist/components/field'
 
-const ProductDetailsVariations = ({variations, onVariationBlur}) => {
+const ProductDetailsVariations = ({variations, onVariationChange}) => {
     return (
         <div>
             {variations.map(({id, label, values = []}) => (
@@ -18,7 +18,7 @@ const ProductDetailsVariations = ({variations, onVariationBlur}) => {
                     key={id}
                     className="u-margin-bottom-lg u-margin-top"
                     customEventHandlers={{
-                        onBlur: onVariationBlur
+                        onChange: onVariationChange
                     }}
                 >
                     <select name={id}>
@@ -41,7 +41,7 @@ ProductDetailsVariations.propTypes = {
             value: PropTypes.string
         }))
     })),
-    onVariationBlur: PropTypes.func
+    onVariationChange: PropTypes.func
 }
 
 const mapStateToProps = createPropsSelector({
@@ -49,7 +49,7 @@ const mapStateToProps = createPropsSelector({
 })
 
 const mapDispatchToProps = {
-    onVariationBlur
+    onVariationChange
 }
 
 export default connect(

--- a/web/app/integration-manager/_demandware-connector/products/commands.js
+++ b/web/app/integration-manager/_demandware-connector/products/commands.js
@@ -40,8 +40,8 @@ export const getProductVariantData = (selections, variants, categoryIds) => (dis
                 browserHistory.push({
                     pathname: getProductHref(id)
                 })
-                return
-            }, 500)
+            }, 250)
+            return
         }
     }
 }

--- a/web/app/integration-manager/_demandware-connector/products/commands.js
+++ b/web/app/integration-manager/_demandware-connector/products/commands.js
@@ -36,10 +36,12 @@ export const getProductVariantData = (selections, variants, categoryIds) => (dis
 
     for (const {values, id} of variants) {
         if (categoryIds.every((id) => selections[id] === values[id])) {
-            browserHistory.push({
-                pathname: getProductHref(id)
-            })
-            return
+            setTimeout(() => {
+                browserHistory.push({
+                    pathname: getProductHref(id)
+                })
+                return
+            }, 500)
         }
     }
 }


### PR DESCRIPTION
# PDP Product Variant selection requires two clicks

The blur event triggered an update of the product images if the user selects a variation, and blurs off of the `<select>`

This PR changes the `onBlur` handlers to an `onChange` for when
the user selects a different variation of an item on the PDP

Prior to this, if a user changed their "item variations" and immediately
clicked "add to cart", the blur event would instead fire, preventing the add
to cart - thus requiring a second click

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-66

## Changes
- Switched `onBlur` event to update image to `onChange` on PDPs

## How to test-drive this PR
- Open `app/main.jsx`.
- Import the Demandware connector:
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1
)
- Navigate to a PDP with multiple variations
- Select a variation, and click add to cart immediately
