### PR TITLE
Add analyze-build npm script

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Rename all files containing JSX to have a .jsx file extension [#525](https://github.com/mobify/platform-scaffold/pull/525)
 - Fix PLP to successfully display no results message if there are no products [#525](https://github.com/mobify/platform-scaffold/pull/525)
 - Update SDK version to 0.14.6 [#557](https://github.com/mobify/platform-scaffold/pull/557)
-- Add analyze-build npm script [#575](https://github.com/mobify/platform-scaffold/pull/575)
+- Add `analyze-build` npm script [#575](https://github.com/mobify/platform-scaffold/pull/575)
 
 ## 0.16.2
 - Update dependencies, including babel, jsdom, jest, and more.

--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Rename all files containing JSX to have a .jsx file extension [#525](https://github.com/mobify/platform-scaffold/pull/525)
 - Fix PLP to successfully display no results message if there are no products [#525](https://github.com/mobify/platform-scaffold/pull/525)
 - Update SDK version to 0.14.6 [#557](https://github.com/mobify/platform-scaffold/pull/557)
+- Add analyze-build npm script [#575](https://github.com/mobify/platform-scaffold/pull/575)
 
 ## 0.16.2
 - Update dependencies, including babel, jsdom, jest, and more.

--- a/web/README.md
+++ b/web/README.md
@@ -218,5 +218,5 @@ npm run dev
 To visualize bundle script content, run:
 
 ```
-MOBIFY_ANALYZE=true npm run prod:build
+npm run analyze-build
 ```

--- a/web/package.json
+++ b/web/package.json
@@ -105,6 +105,7 @@
     "add:component": "sdk-generate component",
     "add:form": "sdk-generate form",
     "add:page": "sdk-generate page",
+    "analyze-build": "MOBIFY_ANALYZE=true npm run prod:build",
     "build-sprites": "npm run clean:svgs && svg-sprite --symbol --symbol-dest='.' --symbol-sprite='sprite.svg' --shape-id-generator='pw-%s' --dest=./app/static/svg/sprite-dist ./app/static/svg/sprite-source/*.svg",
     "clean:svgs": "svgo --enable='removeUselessStrokeAndFill' -f ./app/static/svg/sprite-source",
     "clean:images": "imagemin-power -v --recursive --plugin=pngquant \"./app/static/img/**/*\" --out-dir=.",


### PR DESCRIPTION
This PR is based on a discussion with 64 Labs. They couldn't remember how to run the script as there was no script for it in the project's package.json.

## Changes
- Add `analyze-build` as an NPM script to the build
- Update the web readme

## How to test-drive this PR
- Run `npm run analyze-build`
- Once that's complete, the bundle analyzer page should open
