### PR TITLE
Fix to PLP missing skeletons

### DIFF
--- a/web/app/containers/product-list/partials/product-list-contents.jsx
+++ b/web/app/containers/product-list/partials/product-list-contents.jsx
@@ -26,12 +26,7 @@ const emptySearchText = 'Your search returned no results. Please check your spel
 
 const ResultList = ({products}) => (
     <List className="c--borderless">
-        {products.map((product, idx) => {
-            return product ?
-                <ProductTile key={product.id} {...product} />
-                :
-                <ProductTile key={idx} />
-        })}
+        {products.map((product, idx) => <ProductTile key={product ? product.id : idx} {...product} />)}
     </List>
 )
 

--- a/web/app/containers/product-list/partials/product-list-contents.jsx
+++ b/web/app/containers/product-list/partials/product-list-contents.jsx
@@ -26,8 +26,11 @@ const emptySearchText = 'Your search returned no results. Please check your spel
 
 const ResultList = ({products}) => (
     <List className="c--borderless">
-        {products.map((product) => {
-            return <ProductTile key={product.id} {...product} />
+        {products.map((product, idx) => {
+            return product ?
+                <ProductTile key={product.id} {...product} />
+                :
+                <ProductTile key={idx} />
         })}
     </List>
 )

--- a/web/app/containers/product-list/selectors.js
+++ b/web/app/containers/product-list/selectors.js
@@ -38,7 +38,9 @@ export const getActiveFilters = createSelector(
 export const getFilteredProductListProducts = createSelector(
     getCategoryProducts,
     getActiveFilters,
-    (products, filters) => products.filter(byFilters(filters.toJS()))
+    (products, filters) => {
+        return filters.size > 0 ? products.filter(byFilters(filters.toJS())) : products
+    }
 )
 
 export const getFilteredAndSortedListProducts = createSelector(

--- a/web/app/integration-manager/_merlins-connector/products/parsers.js
+++ b/web/app/integration-manager/_merlins-connector/products/parsers.js
@@ -91,7 +91,7 @@ export const productListParser = ($, $html) => {
         const link = parseTextLink($product.find('.product-item-link'))
         const thumbnail = parseImage($product.find('.product-image-photo'))
         productMap[urlToPathKey(link.href)] = {
-            id: $product.find('.price-box').attr('data-product-id'),
+            id: $product.find('.price-box').length ? $product.find('.price-box').attr('data-product-id') : '',
             title: link.text,
             price: getTextFrom($product, '.price'),
             href: link.href,


### PR DESCRIPTION
This PR fixes the missing product skeletons on the PLP

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-82

## Changes
- Returned filtered results in `getFilteredProductListProducts` only if at least 1 filter is selected
- The products will be `undefined` until the product data is parsed, so this PR also adds a fallback in the product list contents partial to ensure that accessing `id` of `undefined` doesn't throw any errors 

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Navigate to a PLP, ensuring the skeleton appears
