### PR TITLE
Integration manager - Merlins specific getHighResImage

### DIFF
--- a/web/app/containers/checkout-payment/partials/payment-product-item.jsx
+++ b/web/app/containers/checkout-payment/partials/payment-product-item.jsx
@@ -3,7 +3,6 @@
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 
 import React, {PropTypes} from 'react'
-import {getHighResImage} from '../../../integration-manager/_merlins-connector/utils'
 
 // SDK Components
 import Image from 'progressive-web-sdk/dist/components/image'
@@ -24,7 +23,7 @@ const PaymentProductItem = ({
 }) => {
     const productImage = (
         <Image
-            src={getHighResImage(thumbnail.src)}
+            src={thumbnail.src}
             alt={thumbnail.alt}
             width="104px"
             height="104px"

--- a/web/app/integration-manager/_merlins-connector/cart/parser.js
+++ b/web/app/integration-manager/_merlins-connector/cart/parser.js
@@ -5,7 +5,7 @@
 import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 import {textFromFragment, productSubtotal, getHighResImage} from '../utils'
 
-export const parseCartProducts = ({items}) => /* Products */ {
+export const parseCartProducts = ({items}) => { /* Products */
     const products = items.map(({product_id, product_name, product_url, product_price, product_image}) => ({
         id: product_id,
         title: product_name,
@@ -29,7 +29,7 @@ export const parseCartProducts = ({items}) => /* Products */ {
     return productMap
 }
 
-export const parseCart = ({items, subtotal, subtotal_excl_tax}) => /* Cart */ {
+export const parseCart = ({items, subtotal, subtotal_excl_tax}) => { /* Cart */
     return {
         items: items.map(({item_id, product_id, product_url, qty, product_price}) => ({
             id: item_id,


### PR DESCRIPTION
This PR removes the `getHighResImage` call from the `payment-product-item` partial

## Changes
- removes the `getHighResImage` call from the `payment-product-item.jsx` partial, as it was already being called in the Merlin's-specific parser `/_merlins-connector/cart/parser.js`, as seen below

```javascript
{
    thumbnail: {
        src: getHighResImage(product_image.src),
            alt: product_image.alt,
            size: { /* See getHighResImage which has size hard-coded */
                width: '240px',
                height: '300px'
        }
}
```

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Add a product to cart and ensure high res thumbnail is still properly being loaded on Merlin's connector
