### PR TITLE
Add a utility to encapsulate $.ajax for Merlin's

### DIFF
--- a/web/app/integration-manager/_merlins-connector/checkout/commands.js
+++ b/web/app/integration-manager/_merlins-connector/checkout/commands.js
@@ -238,6 +238,8 @@ const buildFormData = (formCredentials) => {
         }
     })
 
+    formData.append('form_key', getCookieValue('form_key'))
+
     return formData
 }
 
@@ -291,7 +293,6 @@ const jqueryAjaxWrapper = (options) => {
 
 const updateBillingAddress = () => (dispatch, getState) => {
     const formData = buildFormData({
-        form_key: getCookieValue('form_key'),
         success_url: '',
         error_url: '',
         ...createAddressRequestObject(paymentSelectors.getPayment(getState())),
@@ -318,7 +319,6 @@ const updateBillingAddress = () => (dispatch, getState) => {
 export const updateShippingAndBilling = () => (dispatch, getState) => {
     const shippingData = shippingSelectors.getShippingAddress(getState()).toJS()
     const formData = buildFormData({
-        form_key: getCookieValue('form_key'),
         success_url: '',
         error_url: '',
         ...createAddressRequestObject(shippingData),


### PR DESCRIPTION
There are a few requests on Merlin's that don't work with `fetch` for some reason. Since raw `XMLHttpRequest` is a pain to work with we use `$.ajax` instead, but it still doesn't fit well into our Promise-based workflow. This PR adds a utility function that wraps $.ajax with a Promise-based interface and centralizes all usage of that function.

 **JIRA**: (link to JIRA ticket)
 **Linked PRs**: (links to corresponding PRs, optional)

## Changes
- Encapsulate $.ajax in a Promise wrapper.

## How to test-drive this PR
- Preview Merlin's
- See that the checkout still works with no 400 errors