### PR TITLE
Adding a change to remove a product that no longer works pre-Integration Manager

### DIFF
--- a/web/app/store/categories/parsers/product-list.js
+++ b/web/app/store/categories/parsers/product-list.js
@@ -11,6 +11,13 @@ const productListParser = ($, $html) => {
           })
           .map(urlToPathKey)
 
+    // TEMPORARY change to remove a product on Merlin's which no longer works with the
+    // current branch. This particular product supports variants, which isn't supported
+    // by the current release, but will be once the Integration Manager changes ship.
+    if (/potions.html/.test(window.location.href)) {
+        products.shift()
+    }
+
     return {
         noResultsText: getTextFrom($html, '.message.empty'),
         itemCount: $numItems.length > 0 ? $numItems.text() : '0',


### PR DESCRIPTION
Adding a change to remove a product that no longer works pre-Integration Manager

## Changes
- TEMPORARY change to remove a product on Merlin's which no longer works with the current branch. This particular product supports variants, which isn't supported by the current release, but will be once the Integration Manager changes ship.

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Make sure https://www.merlinspotions.com/potions/eye-of-newt.html isn't in the list of products on `/potions.html`
