### PR TITLE
[Checkout Schema] Schematize shipping methods

### DIFF
--- a/web/app/containers/checkout-shipping/partials/shipping-method.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-method.jsx
@@ -7,7 +7,7 @@ import {connect} from 'react-redux'
 import {createPropsSelector} from 'reselect-immutable-helpers'
 import * as ReduxForm from 'redux-form'
 
-import {getShippingMethods} from '../../../store/checkout/shipping/selectors'
+import {getShippingMethods} from '../../../store/checkout/selectors'
 
 import Button from 'progressive-web-sdk/dist/components/button'
 import Field from 'progressive-web-sdk/dist/components/field'

--- a/web/app/containers/checkout-shipping/partials/shipping-method.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-method.jsx
@@ -15,38 +15,38 @@ import FieldRow from 'progressive-web-sdk/dist/components/field-row'
 import ShippingMethodLabel from './shipping-method-label'
 
 
-const ShippingMethod = ({shippingMethods}) => {
-    return (
-        <div className="t-checkout-shipping__shipping-method">
-            <div className="t-checkout-shipping__title u-padding-top-lg u-padding-bottom-md">
-                <h2 className="u-h4 u-text-uppercase">Shipping Method</h2>
-            </div>
-
-            <div className="u-padding-md u-border-light-top u-border-light-bottom u-bg-color-neutral-00">
-                {shippingMethods && shippingMethods.map(({label, info, cost, value}, idx) => {
-                    return (
-                        <FieldRow key={idx}>
-                            <ReduxForm.Field
-                                component={Field}
-                                name="shipping_method"
-                                type="radio"
-                                value={value}
-                                label={<ShippingMethodLabel label={label} info={info} cost={cost} />}
-                            >
-                                <input type="radio" noValidate />
-                            </ReduxForm.Field>
-                        </FieldRow>
-                    )
-                })}
-
-                <FieldRow className="u-margin-top-lg">
-                    <Button type="submit" className="c--primary u-width-full u-text-uppercase qa-checkout__continue-to-payment">
-                        Continue to Payment
-                    </Button>
-                </FieldRow>
-            </div>
+const ShippingMethod = ({shippingMethods}) => (
+    <div className="t-checkout-shipping__shipping-method">
+        <div className="t-checkout-shipping__title u-padding-top-lg u-padding-bottom-md">
+            <h2 className="u-h4 u-text-uppercase">Shipping Method</h2>
         </div>
-    )
+
+        <div className="u-padding-md u-border-light-top u-border-light-bottom u-bg-color-neutral-00">
+            {shippingMethods.map(({label, info, cost, id}) => (
+                <FieldRow key={id}>
+                    <ReduxForm.Field
+                        component={Field}
+                        name="shipping_method"
+                        type="radio"
+                        value={id}
+                        label={<ShippingMethodLabel label={label} info={info} cost={cost} />}
+                    >
+                        <input type="radio" noValidate />
+                    </ReduxForm.Field>
+                </FieldRow>
+            ))}
+
+            <FieldRow className="u-margin-top-lg">
+                <Button type="submit" className="c--primary u-width-full u-text-uppercase qa-checkout__continue-to-payment">
+                    Continue to Payment
+                </Button>
+            </FieldRow>
+        </div>
+    </div>
+)
+
+ShippingMethod.defaultProps = {
+    shippingMethods: []
 }
 
 ShippingMethod.propTypes = {
@@ -57,12 +57,8 @@ ShippingMethod.propTypes = {
         cost: PropTypes.string,
         info: PropTypes.string,
         label: PropTypes.string,
-        value: PropTypes.string
-    })),
-    /**
-    * (Internal) Added by redux form
-    */
-    submitting: PropTypes.bool
+        id: PropTypes.string
+    }))
 }
 
 const mapStateToProps = createPropsSelector({

--- a/web/app/integration-manager/_merlins-connector/checkout/commands.js
+++ b/web/app/integration-manager/_merlins-connector/checkout/commands.js
@@ -10,7 +10,14 @@ import {parseCartTotals} from '../cart/parser'
 import {parseCheckoutEntityID, extractMagentoShippingStepData} from '../../../utils/magento-utils'
 import {parseLocationData} from '../../../utils/utils'
 import {getCart} from '../cart/commands'
-import {receiveCheckoutData, receiveCheckoutLocations, receiveShippingInitialValues, receiveCheckoutConfirmationData, receiveBillingInitialValues} from './../../checkout/results'
+import {
+    receiveCheckoutData,
+    receiveCheckoutLocations,
+    receiveShippingInitialValues,
+    receiveCheckoutConfirmationData,
+    receiveBillingInitialValues,
+    receiveShippingMethods
+} from './../../checkout/results'
 import {receiveCartContents} from './../../cart/results'
 import {fetchPageData} from '../app/commands'
 import {getCustomerEntityID} from '../selectors'
@@ -43,7 +50,7 @@ export const fetchShippingMethodsEstimate = (formKey) => (dispatch, getState) =>
                 ...address
             }
 
-            dispatch(receiveCheckoutData({shipping: {shippingMethods}}))
+            dispatch(receiveShippingMethods(shippingMethods))
             dispatch(receiveShippingInitialValues({address: initialValues})) // set initial value for method
         })
 }

--- a/web/app/integration-manager/_merlins-connector/checkout/parsers.js
+++ b/web/app/integration-manager/_merlins-connector/checkout/parsers.js
@@ -56,13 +56,11 @@ export const parseShippingMethods = (shippingMethods) => {
     if (!shippingMethods || !shippingMethods.map) {
         return []
     }
-    return shippingMethods.map((method) => {
-        return {
-            label: `${method.method_title} - ${method.carrier_title}`,
-            cost: `$${method.price_incl_tax.toFixed(2)}`,
-            value: `${method.carrier_code}_${method.method_code}`
-        }
-    })
+    return shippingMethods.map((method) => ({
+        label: `${method.method_title} - ${method.carrier_title}`,
+        cost: `$${method.price_incl_tax.toFixed(2)}`,
+        id: `${method.carrier_code}_${method.method_code}`
+    }))
 }
 
 export const checkoutConfirmationParser = ($, $html) => {

--- a/web/app/integration-manager/_sfcc-connector/checkout/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/checkout/commands.js
@@ -12,7 +12,7 @@ import {getPaymentURL, getConfirmationURL} from '../config'
 import {STATES} from './constants'
 import {receiveOrderConfirmationContents} from '../../results'
 import {getCardData} from 'progressive-web-sdk/dist/card-utils'
-import {receiveCheckoutData, receiveCheckoutLocations, receiveShippingInitialValues, receiveBillingInitialValues} from './../../checkout/results'
+import {receiveShippingMethods, receiveCheckoutLocations, receiveShippingInitialValues, receiveBillingInitialValues} from './../../checkout/results'
 
 export const fetchShippingMethodsEstimate = () => (dispatch) => {
     return createBasket()
@@ -23,10 +23,10 @@ export const fetchShippingMethodsEstimate = () => (dispatch) => {
                   .map(({name, description, price, id}) => ({
                       label: `${name} - ${description}`,
                       cost: `$${price.toFixed(2)}`,
-                      value: id
+                      id
                   }))
 
-            return dispatch(receiveCheckoutData({shipping: {shippingMethods}}))
+            return dispatch(receiveShippingMethods(shippingMethods))
         })
 }
 

--- a/web/app/integration-manager/checkout/results.js
+++ b/web/app/integration-manager/checkout/results.js
@@ -4,9 +4,10 @@
 
 import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
 import {createTypedAction} from '../../utils/utils'
-import {LocationList} from './types'
+import {LocationList, ShippingMethods} from './types'
 
 export const receiveCheckoutLocations = createTypedAction('Receive Checkout Locations', LocationList, 'locations')
+export const receiveShippingMethods = createTypedAction('Receive Shipping Methods', ShippingMethods)
 
 export const receiveCheckoutData = createAction('Receive Checkout Data')
 export const receiveCheckoutCustomContent = createAction('Receive Checkout Custom Content', ['custom'])

--- a/web/app/integration-manager/checkout/types.js
+++ b/web/app/integration-manager/checkout/types.js
@@ -3,7 +3,7 @@
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 
 import * as Runtypes from 'runtypes'
-import {Identifier, Text} from '../types'
+import {Identifier, Text, Money} from '../types'
 
 const CountryID = Identifier
 
@@ -24,3 +24,12 @@ export const LocationList = Runtypes.Record({
     countries: Runtypes.Array(Country),
     regions: Runtypes.Array(Region)
 })
+
+
+const ShippingMethod = Runtypes.Record({
+    label: Text,
+    cost: Money,
+    id: Identifier
+})
+
+export const ShippingMethods = Runtypes.Array(ShippingMethod)

--- a/web/app/store/checkout/reducer.js
+++ b/web/app/store/checkout/reducer.js
@@ -24,6 +24,11 @@ const checkoutReducer = handleActions({
     [integrationManagerResults.receiveBillingAddressCustomContent]: setCustomContent('billing', 'address'),
     [integrationManagerResults.receivePaymentCustomContent]: setCustomContent('payment'),
     [integrationManagerResults.receivePaymentAddressCustomContent]: setCustomContent('payment', 'address'),
+    [integrationManagerResults.receiveShippingMethods]: (state, {payload}) => (
+        // Using `set` here will make sure the list in the store is
+        // correctly truncated.
+        state.set('shippingMethods', payload)
+    ),
     [setDefaultShippingAddressId]: mergePayload
 }, Immutable.Map())
 

--- a/web/app/store/checkout/selectors.js
+++ b/web/app/store/checkout/selectors.js
@@ -30,5 +30,7 @@ export const getAvailableRegions = (formKey) => createSelector(
     (regions, id) => regions.filter((region) => region.get('countryId') === id)
 )
 
+export const getShippingMethods = createGetSelector(getCheckout, 'shippingMethods', Immutable.List())
+
 export const getCheckoutCustomContent = createGetSelector(getCheckout, 'custom')
 export const getLocationsCustomContent = createGetSelector(getLocations, 'custom')

--- a/web/app/store/checkout/shipping/selectors.js
+++ b/web/app/store/checkout/shipping/selectors.js
@@ -6,14 +6,13 @@ import {createSelector} from 'reselect'
 import Immutable from 'immutable'
 import {createGetSelector} from 'reselect-immutable-helpers'
 import {getCheckout} from '../../selectors'
+import {getShippingMethods} from '../selectors'
 
 export const getShipping = createGetSelector(getCheckout, 'shipping', Immutable.Map())
 
 export const getShippingCustomContent = createGetSelector(getShipping, 'custom')
 
 export const getSavedAddresses = createGetSelector(getCheckout, 'savedAddresses', Immutable.List())
-
-export const getShippingMethods = createGetSelector(getShipping, 'shippingMethods', Immutable.List())
 
 export const getShippingAddress = createGetSelector(getShipping, 'address', Immutable.Map())
 
@@ -38,7 +37,7 @@ export const getSelectedShippingMethod = createSelector(
         if (!shippingMethods.size) {
             return Immutable.Map()
         }
-        const selectedValue = shippingMethods.filter((method) => method.get('value') === selectedMethodValue)
+        const selectedValue = shippingMethods.filter((method) => method.get('id') === selectedMethodValue)
         return selectedValue.size ? selectedValue.get(0) : shippingMethods.get(0)
     })
 


### PR DESCRIPTION
This PR schematizes the shipping methods in the Redux store and integration manager, and moves them out of the `shipping` branch. 

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-69
 **Linked PRs**: (links to corresponding PRs, optional)

## Changes
- Create the schema types and actions
- Dispatch matching data from the connectors
- Accept matching data in the UI

## How to test-drive this PR
- Preview Merlin's and DW
- See that the shipping options on the shipping page still work
