### PR TITLE
Store the app on-boarding carousel data in an array instead of an object

### DIFF
--- a/web/app/containers/onboarding/container.jsx
+++ b/web/app/containers/onboarding/container.jsx
@@ -8,9 +8,9 @@ import CarouselItem from 'progressive-web-sdk/dist/components/carousel/carousel-
 import Carousel from 'progressive-web-sdk/dist/components/carousel'
 import Button from 'progressive-web-sdk/dist/components/button'
 
-const OnboardingScreen = ({imageURL, imageAlt, title, subtitle, primaryButton, laterButton, actionButton, key}) => {
+const OnboardingScreen = ({imageURL, imageAlt, title, subtitle, primaryButton, laterButton, actionButton, id}) => {
     return (
-        <CarouselItem caption="Get started" key={key} className="carousel-item">
+        <CarouselItem caption="Get started" key={id} className="carousel-item">
             <div className="carousel-item-wrapper u-direction-column">
                 <div className="u-flex u-flexbox u-align-center u-justify-center">
                     <div>
@@ -41,9 +41,9 @@ const OnboardingScreen = ({imageURL, imageAlt, title, subtitle, primaryButton, l
 
 OnboardingScreen.propTypes = {
     actionButton: React.PropTypes.object,
+    id: React.PropTypes.string,
     imageAlt: React.PropTypes.string,
     imageURL: React.PropTypes.string,
-    key: React.PropTypes.string,
     laterButton: React.PropTypes.object,
     primaryButton: React.PropTypes.object,
     subtitle: React.PropTypes.string,
@@ -53,13 +53,13 @@ OnboardingScreen.propTypes = {
 const Onboarding = ({carouselData}) => {
     return (
         <Carousel allowLooping={false}>
-            {Object.keys(carouselData).map((key) => <OnboardingScreen {...carouselData[key]} key={key} />)}
+            {carouselData.map((val, idx) => <OnboardingScreen {...val} id={idx.toString()} key={idx.toString()} />)}
         </Carousel>
     )
 }
 
 Onboarding.propTypes = {
-    carouselData: React.PropTypes.object
+    carouselData: React.PropTypes.array
 }
 
 export default Onboarding

--- a/web/app/native/onboarding/onboarding.jsx
+++ b/web/app/native/onboarding/onboarding.jsx
@@ -69,17 +69,19 @@ const login = {
     }
 }
 
-const carouselData = {
-    location,
-    login
-}
+const carouselData = [
+    location
+]
 
 // MESSAGING_ENABLED is replaced at build time by webpack.
 if (MESSAGING_ENABLED) {
-    carouselData.notifications = notifications
+    carouselData.push(notifications)
 }
 
 const rootEl = document.getElementsByClassName('react-target')[0]
+
+// Login should always be the last stage, so do this last
+carouselData.push(login)
 
 // There's a bug in the Android webview that doesn't immediately register
 // the event handlers for the carousel, so we delay rendering to next runloop


### PR DESCRIPTION
So whether or not messaging is enabled, the order is correct. 

 **JIRA**: https://mobify.atlassian.net/browse/HYB-1044

## Changes
- Store the app on-boarding carousel data in an array instead of an object

## How to test-drive this PR
- `npm run deps` in `native/`
- Run `npm run dev` in `web/
- Run the iOS or Android app
- Observe the onboarding order is correct
- Toggle `messagingEnabled` in `package.json` in both `native/` and `web/`, re-run test, observe the order is still correct