### PR TITLE
SFCC confirmation page bug fix

### DIFF
--- a/web/app/integration-manager/_sfcc-connector/cart/utils.js
+++ b/web/app/integration-manager/_sfcc-connector/cart/utils.js
@@ -131,3 +131,10 @@ export const handleCartData = (basket) => (dispatch) => {
 
     return dispatch(fetchCartItemImages())
 }
+
+
+export const createNewBasket = () => (dispatch) => {
+    deleteBasketID()
+    return requestCartData()
+        .then((basket) => dispatch(handleCartData(basket)))
+}

--- a/web/app/integration-manager/_sfcc-connector/checkout/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/checkout/commands.js
@@ -4,7 +4,7 @@
 
 import {SubmissionError} from 'redux-form'
 import {createBasket, handleCartData, requestCartData, createNewBasket} from '../cart/utils'
-import {makeApiRequest, makeApiJsonRequest, getAuthToken, getAuthTokenPayload, deleteBasketID} from '../utils'
+import {makeApiRequest, makeApiJsonRequest, getAuthToken, getAuthTokenPayload} from '../utils'
 import {getOrderTotal} from '../../../store/cart/selectors'
 import {populateLocationsData, createOrderAddressObject} from './utils'
 import {parseShippingAddressFromBasket} from './parsers'

--- a/web/app/integration-manager/_sfcc-connector/checkout/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/checkout/commands.js
@@ -3,8 +3,8 @@
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 
 import {SubmissionError} from 'redux-form'
-import {createBasket, handleCartData, requestCartData} from '../cart/utils'
-import {makeApiRequest, makeApiJsonRequest, getAuthToken, getAuthTokenPayload} from '../utils'
+import {createBasket, handleCartData, requestCartData, createNewBasket} from '../cart/utils'
+import {makeApiRequest, makeApiJsonRequest, getAuthToken, getAuthTokenPayload, deleteBasketID} from '../utils'
 import {getOrderTotal} from '../../../store/cart/selectors'
 import {populateLocationsData, createOrderAddressObject} from './utils'
 import {parseShippingAddressFromBasket} from './parsers'
@@ -206,6 +206,10 @@ export const submitPayment = (formValues) => (dispatch) => {
             dispatch(receiveOrderConfirmationContents({
                 orderNumber: order.order_no
             }))
+            // The new basket data isn't required for the confirmation page,
+            // so we can return the URL without waiting for this to complete
+            dispatch(createNewBasket())
+
             return getConfirmationURL()
         })
 }


### PR DESCRIPTION
This PR fixes a bug on the SFCC confirmation page where the user's basket wasn't getting cleared after completing an order.

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-49
 **Linked PRs**: n/a

## Changes
- Added "createNewBasket" function to cart utils
- Called createNewBasket once an order has been placed

## How to test-drive this PR
- Run `npm run dev`
- Preview the [SFCC Site](https://preview.mobify.com/?url=https%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- add an item to your cart
- proceed through the checkout to complete the order
- click "continue shopping" on the confirmation page
- the mini-cart should show as empty when you reach the homepage
