### PR TITLE
Fixes the offline mode hanging on uncached pages

### DIFF
--- a/web/app/template.jsx
+++ b/web/app/template.jsx
@@ -27,8 +27,8 @@ const template = (WrappedComponent) => {
             if (route.fetchAction) {
                 dispatch(route.fetchAction(route.fetchUrl || url, route.routeName))
                     .then(() => dispatch(setFetchedPage(url)))
-                    .then(() => dispatch(checkIfOffline()))
                     .catch((error) => console.error(`Error executing fetch action for ${route.routeName}`, error))
+                    .then(() => dispatch(checkIfOffline()))
             }
             dispatch(removeAllNotifications())
         }


### PR DESCRIPTION
# Fixes the offline mode hanging on uncached pages

**NOTE:** The ticket describes this issue as occurring only on PLPs, but this would happen on any route change to an uncached page.

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-92
 **Linked PRs**: N/A

## Changes
- Placed the `checkIfOffline` dispatch after the `catch` for a route's fetchActions, thus allowing for offline mode to be set even if a fetch action fails

## How to test-drive this PR
- Use Merlin's Connector
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Clear your cache in Application tab of dev tools (named progressive-web-scaffold-<version>)
- Turn on offline mode in applications tab or network tab in dev tools
- Navigate somewhere, and make sure that you don't see skeletons forever 💀 !!
