### PR TITLE
[Checkout Schema] move billingSameAsShipping key

### DIFF
--- a/web/app/containers/checkout-payment/actions.js
+++ b/web/app/containers/checkout-payment/actions.js
@@ -21,7 +21,7 @@ export const setCvvType = createAction('Setting CVV type', ['cvvType'])
 export const submitPayment = () => (dispatch, getState) => {
     const currentState = getState()
     const billingFormValues = getPaymentBillingFormValues(currentState)
-    const billingIsSameAsShippingAddress = billingFormValues.billing_same_as_shipping
+    const billingIsSameAsShippingAddress = billingFormValues.billingSameAsShipping
 
     // Careful. This get's completely overwritten below
     let address = null

--- a/web/app/containers/checkout-payment/actions.test.js
+++ b/web/app/containers/checkout-payment/actions.test.js
@@ -23,7 +23,7 @@ test('submitPayment calls submitPayment command', () => {
         form: {
             [PAYMENT_FORM_NAME]: {
                 values: {
-                    billing_same_as_shipping: false,
+                    billingSameAsShipping: false,
                     name: 'Test Name'
                 }
             }

--- a/web/app/containers/checkout-payment/partials/billing-address-form.jsx
+++ b/web/app/containers/checkout-payment/partials/billing-address-form.jsx
@@ -83,7 +83,7 @@ class BillingAddressForm extends React.Component {
                         <FieldRow className="u-padding-md">
                             <ReduxForm.Field
                                 component={Field}
-                                name="billing_same_as_shipping"
+                                name="billingSameAsShipping"
                                 type="checkbox"
                                 label={<strong className="u-text-weight-medium">Same as shipping address</strong>}
                                 caption={shippingAddress}

--- a/web/app/containers/checkout-payment/partials/checkout-payment-form.jsx
+++ b/web/app/containers/checkout-payment/partials/checkout-payment-form.jsx
@@ -9,7 +9,7 @@ import {createPropsSelector} from 'reselect-immutable-helpers'
 
 // Selectors
 import {PAYMENT_FORM_NAME} from '../../../store/form/constants'
-import {getBillingAddress} from '../../../store/checkout/billing/selectors'
+import {getBillingInitialValues} from '../../../store/checkout/billing/selectors'
 
 // Actions
 import {submitPayment} from '../actions'
@@ -54,7 +54,7 @@ CheckoutPaymentForm.propTypes = {
 }
 
 const mapStateToProps = createPropsSelector({
-    initialValues: getBillingAddress
+    initialValues: getBillingInitialValues
 })
 
 const mapDispatchToProps = {

--- a/web/app/integration-manager/_merlins-connector/checkout/commands.js
+++ b/web/app/integration-manager/_merlins-connector/checkout/commands.js
@@ -14,7 +14,8 @@ import {
     receiveShippingAddress,
     receiveCheckoutConfirmationData,
     receiveBillingAddress,
-    receiveShippingMethods
+    receiveShippingMethods,
+    receiveBillingSameAsShipping
 } from './../../checkout/results'
 import {receiveCartContents} from './../../cart/results'
 import {fetchPageData} from '../app/commands'
@@ -154,7 +155,8 @@ export const initCheckoutPaymentPage = (url) => (dispatch, getState) => {
         .then((res) => {
             const [$, $response] = res // eslint-disable-line no-unused-vars
             const addressData = shippingSelectors.getInitialShippingAddress(getState()).toJS()
-            dispatch(receiveBillingAddress({...addressData, billing_same_as_shipping: true}))
+            dispatch(receiveBillingSameAsShipping(true))
+            dispatch(receiveBillingAddress(addressData))
             return dispatch(processCheckoutData($response))
         })
 }
@@ -206,7 +208,6 @@ export const submitPayment = (formValues) => (dispatch, getState) => {
     }
 
     const persistPaymentURL = `${cartBaseUrl}/payment-information`
-    dispatch(receiveBillingAddress(address))
     return makeJsonEncodedRequest(persistPaymentURL, paymentInformation, {method: 'POST'})
         .then((response) => response.json())
         .then((responseJSON) => {

--- a/web/app/integration-manager/_merlins-connector/checkout/parsers.js
+++ b/web/app/integration-manager/_merlins-connector/checkout/parsers.js
@@ -27,8 +27,7 @@ export const parseShippingInitialValues = (shippingFieldData) => {
         countryId: fieldData.country_id.value,
         regionId: fieldData.region_id.value,
         postcode: fieldData.postcode.value,
-        telephone: fieldData.telephone.value,
-        billing_same_as_shipping: true
+        telephone: fieldData.telephone.value
     }
 
     // Remove undefined keys to prevent valid content being overriden in the store

--- a/web/app/integration-manager/_sfcc-connector/checkout/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/checkout/commands.js
@@ -11,7 +11,7 @@ import {parseShippingAddressFromBasket} from './parsers'
 import {getPaymentURL, getConfirmationURL} from '../config'
 import {receiveOrderConfirmationContents} from '../../results'
 import {getCardData} from 'progressive-web-sdk/dist/card-utils'
-import {receiveShippingMethods, receiveShippingAddress, receiveBillingAddress} from './../../checkout/results'
+import {receiveShippingMethods, receiveShippingAddress, receiveBillingAddress, receiveBillingSameAsShipping} from './../../checkout/results'
 
 export const fetchShippingMethodsEstimate = (inputAddress) => (dispatch) => {
     return createBasket()
@@ -88,7 +88,8 @@ export const initCheckoutPaymentPage = () => (dispatch) => {
             const addressData = parseShippingAddressFromBasket(basket)
 
             dispatch(receiveShippingAddress(addressData))
-            dispatch(receiveBillingAddress({...addressData, billing_same_as_shipping: true}))
+            dispatch(receiveBillingSameAsShipping(true))
+            dispatch(receiveBillingAddress(addressData))
         })
 }
 
@@ -155,7 +156,7 @@ const addPaymentMethod = (formValues, basket) => (dispatch, getState) => {
 }
 
 const setBillingAddress = (formValues, basket) => () => {
-    if (formValues.billing_same_as_shipping) {
+    if (formValues.billingSameAsShipping) {
         // No change to the address is necessary
         return Promise.resolve(basket)
     }

--- a/web/app/integration-manager/checkout/results.js
+++ b/web/app/integration-manager/checkout/results.js
@@ -16,6 +16,8 @@ export const receiveCheckoutCustomContent = createAction('Receive Checkout Custo
 export const receiveShippingAddress = createAction('Receive Shipping Initial Values', ['shippingAddress'])
 export const receiveHasExistingCard = createAction('Receive Has Existing Cart flag', ['hasExistingCreditCard'])
 export const receiveBillingAddress = createAction('Receive Billing Initial Values', ['billingAddress'])
+export const receiveBillingSameAsShipping = createAction('Receive Billing same as Shipping', ['billingSameAsShipping'])
+
 
 const remapProducts = (products) => {
     const mappedProducts = []

--- a/web/app/store/checkout/billing/selectors.js
+++ b/web/app/store/checkout/billing/selectors.js
@@ -3,9 +3,17 @@
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 
 import Immutable from 'immutable'
+import {createSelector} from 'reselect'
 import {createGetSelector} from 'reselect-immutable-helpers'
 import {getCheckout} from '../../selectors'
+import {getBillingSameAsShipping} from '../selectors'
 
 export const getBillingAddress = createGetSelector(getCheckout, 'billingAddress', Immutable.Map())
+
+export const getBillingInitialValues = createSelector(
+    getBillingAddress,
+    getBillingSameAsShipping,
+    (billingAddress, billingSameAsShipping) => billingAddress.merge({billingSameAsShipping})
+)
 
 export const getBillingAddressCustomContent = createGetSelector(getBillingAddress, 'custom')

--- a/web/app/store/checkout/billing/selectors.js
+++ b/web/app/store/checkout/billing/selectors.js
@@ -13,7 +13,7 @@ export const getBillingAddress = createGetSelector(getCheckout, 'billingAddress'
 export const getBillingInitialValues = createSelector(
     getBillingAddress,
     getBillingSameAsShipping,
-    (billingAddress, billingSameAsShipping) => billingAddress.merge({billingSameAsShipping})
+    (billingAddress, billingSameAsShipping) => billingAddress.set('billingSameAsShipping', billingSameAsShipping)
 )
 
 export const getBillingAddressCustomContent = createGetSelector(getBillingAddress, 'custom')

--- a/web/app/store/checkout/reducer.js
+++ b/web/app/store/checkout/reducer.js
@@ -17,6 +17,7 @@ const checkoutReducer = handleActions({
     [integrationManagerResults.receiveCheckoutData]: mergePayload,
     [integrationManagerResults.receiveUserEmail]: mergePayload,
     [integrationManagerResults.receiveCheckoutCustomContent]: mergePayload,
+    [integrationManagerResults.receiveBillingSameAsShipping]: mergePayload,
     [integrationManagerResults.receiveLocationsCustomContent]: setCustomContent('locations'),
     [integrationManagerResults.receiveShippingAddressCustomContent]: setCustomContent('shippingAddress'),
     [integrationManagerResults.receiveBillingAddressCustomContent]: setCustomContent('billingAddress'),

--- a/web/app/store/checkout/selectors.js
+++ b/web/app/store/checkout/selectors.js
@@ -15,6 +15,8 @@ export const getLocations = createGetSelector(getCheckout, 'locations', Immutabl
 export const getCountries = createGetSelector(getLocations, 'countries', Immutable.List())
 export const getRegions = createGetSelector(getLocations, 'regions', Immutable.List())
 
+export const getBillingSameAsShipping = createGetSelector(getCheckout, 'billingSameAsShipping')
+
 export const getSelectedCountryID = (formKey) => createSelector(
     getFormValues(formKey),
     (values) => {


### PR DESCRIPTION
This PR moves the billingSameAsShipping key to the root of the checkout store.

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-69
 **Linked PRs**: n/a

## Changes
- Renamed the billingSameAsShipping input to follow our naming conventions (ie. no underscores)
- Moved billingSameAsShipping to the root of the checkout store (results, reducers, selectors updated)
- Updated commands & actions to handle new location for billingSameAsShipping key
- Created new selector for billing address initial values that combines billingAddress with billingSameAsShipping

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- add an item to the cart
- proceed through the checkout 
- test placing an order with billing same as shipping and with billing different from shipping
- repeat the steps using the [SFCC Site](https://preview.mobify.com/?url=https%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)