### PR TITLE
[Checkout Schema] move selected shipping method

### DIFF
--- a/web/app/containers/checkout-shipping/actions.js
+++ b/web/app/containers/checkout-shipping/actions.js
@@ -8,7 +8,8 @@ import {browserHistory} from 'progressive-web-sdk/dist/routing'
 import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
 
 import {splitFullName} from '../../utils/utils'
-import {receiveCheckoutData, receiveShippingAddress} from '../../integration-manager/checkout/results'
+import {receiveCheckoutData, receiveShippingAddress, receiveSelectedShippingMethod} from '../../integration-manager/checkout/results'
+
 
 import {
     submitShipping as submitShippingCommand,
@@ -70,6 +71,7 @@ export const submitShipping = () => (dispatch, getState) => {
     if (formValues.username) {
         dispatch(receiveCheckoutData({emailAddress: formValues.username}))
     }
+    dispatch(receiveSelectedShippingMethod(formValues.shippingMethodId))
     dispatch(receiveShippingAddress(address))
     return dispatch(submitShippingCommand(address))
         .then((paymentURL) => {

--- a/web/app/containers/checkout-shipping/actions.js
+++ b/web/app/containers/checkout-shipping/actions.js
@@ -60,20 +60,40 @@ export const submitSignIn = () => (dispatch, getState) => {
 
 export const submitShipping = () => (dispatch, getState) => {
     const currentState = getState()
-    const formValues = getShippingFormValues(currentState)
-    const {firstname, lastname} = splitFullName(formValues.name)
+    const {
+        name,
+        company,
+        addressLine1,
+        addressLine2,
+        countryId,
+        city,
+        regionId,
+        postcode,
+        telephone,
+        shippingMethodId,
+        username
+    } = getShippingFormValues(currentState)
+    const {firstname, lastname} = splitFullName(name)
     const address = {
         firstname,
         lastname,
-        ...formValues
+        name,
+        company,
+        addressLine1,
+        addressLine2,
+        countryId,
+        city,
+        regionId,
+        postcode,
+        telephone,
     }
 
-    if (formValues.username) {
-        dispatch(receiveCheckoutData({emailAddress: formValues.username}))
+    if (username) {
+        dispatch(receiveCheckoutData({emailAddress: username}))
     }
-    dispatch(receiveSelectedShippingMethod(formValues.shippingMethodId))
+    dispatch(receiveSelectedShippingMethod(shippingMethodId))
     dispatch(receiveShippingAddress(address))
-    return dispatch(submitShippingCommand(address))
+    return dispatch(submitShippingCommand({...address, shippingMethodId}))
         .then((paymentURL) => {
             browserHistory.push({
                 pathname: paymentURL

--- a/web/app/containers/checkout-shipping/partials/shipping-method.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-method.jsx
@@ -26,7 +26,7 @@ const ShippingMethod = ({shippingMethods}) => (
                 <FieldRow key={id}>
                     <ReduxForm.Field
                         component={Field}
-                        name="shipping_method"
+                        name="shippingMethodId"
                         type="radio"
                         value={id}
                         label={<ShippingMethodLabel label={label} info={info} cost={cost} />}

--- a/web/app/integration-manager/_merlins-connector/checkout/commands.js
+++ b/web/app/integration-manager/_merlins-connector/checkout/commands.js
@@ -117,8 +117,8 @@ export const submitShipping = (formValues) => (dispatch, getState) => {
     }
 
     // Prepare and then run Shipping Information request
-    const {shipping_method} = formValues
-    const shippingSelections = shipping_method.split('_')
+    const {shippingMethodId} = formValues
+    const shippingSelections = shippingMethodId.split('_')
     const addressData = {
         addressInformation: {
             shippingAddress: address,

--- a/web/app/integration-manager/_sfcc-connector/checkout/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/checkout/commands.js
@@ -119,7 +119,7 @@ const setShippingAddress = (formValues, basket) => () => (
 const setShippingMethod = (formValues, basket) => () => (
     makeApiJsonRequest(
         `/baskets/${basket.basket_id}/shipments/me/shipping_method`,
-        {id: formValues.shipping_method},
+        {id: formValues.shippingMethodId},
         {method: 'PUT'}
     )
 )

--- a/web/app/integration-manager/_sfcc-connector/checkout/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/checkout/commands.js
@@ -11,7 +11,7 @@ import {parseShippingAddressFromBasket} from './parsers'
 import {getPaymentURL, getConfirmationURL} from '../config'
 import {receiveOrderConfirmationContents} from '../../results'
 import {getCardData} from 'progressive-web-sdk/dist/card-utils'
-import {receiveShippingMethods, receiveShippingAddress, receiveBillingAddress} from './../../checkout/results'
+import {receiveShippingMethods, receiveShippingAddress, receiveBillingAddress, receiveSelectedShippingMethod} from './../../checkout/results'
 
 export const fetchShippingMethodsEstimate = (inputAddress) => (dispatch) => {
     return createBasket()
@@ -26,13 +26,12 @@ export const fetchShippingMethodsEstimate = (inputAddress) => (dispatch) => {
                   }))
 
             dispatch(receiveShippingAddress({
-                shipping_method: shippingMethods[0].id,
                 postcode: inputAddress.postcode,
                 countryId: inputAddress.countryId,
                 region: inputAddress.region,
                 regionId: inputAddress.regionId
             })) // set initial values for the shipping form
-
+            dispatch(receiveSelectedShippingMethod(shippingMethods[0].id))
             return dispatch(receiveShippingMethods(shippingMethods))
         })
 }
@@ -63,14 +62,14 @@ export const initCheckoutShippingPage = () => (dispatch) => {
                     city: shipping_address.city,
                     regionId: shipping_address.state_code,
                     postcode: shipping_address.postal_code,
-                    telephone: shipping_address.phone,
-                    shipping_method: shipping_method ? shipping_method.id : undefined
+                    telephone: shipping_address.phone
                 }
             } else {
                 initialValues = {
                     countryId: 'us'
                 }
             }
+            dispatch(receiveSelectedShippingMethod(shipping_method ? shipping_method.id : undefined))
             dispatch(receiveShippingAddress(initialValues))
             /* eslint-enable camelcase */
             return dispatch(populateLocationsData())
@@ -85,8 +84,10 @@ export const initCheckoutPaymentPage = () => (dispatch) => {
     dispatch(populateLocationsData())
     return requestCartData()
         .then((basket) => {
+            const shippingMethod = basket.shipments[0].shipping_method
             const addressData = parseShippingAddressFromBasket(basket)
 
+            dispatch(receiveSelectedShippingMethod(shippingMethod ? shippingMethod.id : undefined))
             dispatch(receiveShippingAddress(addressData))
             dispatch(receiveBillingAddress({...addressData, billing_same_as_shipping: true}))
         })

--- a/web/app/integration-manager/_sfcc-connector/checkout/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/checkout/commands.js
@@ -11,9 +11,11 @@ import {parseShippingAddressFromBasket} from './parsers'
 import {getPaymentURL, getConfirmationURL} from '../config'
 import {receiveOrderConfirmationContents} from '../../results'
 import {getCardData} from 'progressive-web-sdk/dist/card-utils'
+import {getSelectedShippingMethodValue} from '../../../store/checkout/shipping/selectors'
 import {receiveShippingMethods, receiveShippingAddress, receiveBillingAddress, receiveSelectedShippingMethod} from './../../checkout/results'
 
-export const fetchShippingMethodsEstimate = (inputAddress) => (dispatch) => {
+export const fetchShippingMethodsEstimate = (inputAddress) => (dispatch, getState) => {
+    const selectedShippingMethodId = getSelectedShippingMethodValue(getState())
     return createBasket()
         .then((basket) => makeApiRequest(`/baskets/${basket.basket_id}/shipments/me/shipping_methods`, {method: 'GET'}))
         .then((response) => response.json())
@@ -31,7 +33,7 @@ export const fetchShippingMethodsEstimate = (inputAddress) => (dispatch) => {
                 region: inputAddress.region,
                 regionId: inputAddress.regionId
             })) // set initial values for the shipping form
-            dispatch(receiveSelectedShippingMethod(shippingMethods[0].id))
+            dispatch(receiveSelectedShippingMethod(selectedShippingMethodId || shippingMethods[0].id))
             return dispatch(receiveShippingMethods(shippingMethods))
         })
 }

--- a/web/app/integration-manager/_sfcc-connector/checkout/parsers.js
+++ b/web/app/integration-manager/_sfcc-connector/checkout/parsers.js
@@ -8,8 +8,7 @@ export const parseShippingAddressFromBasket = (basketData) => {
             email
         },
         shipments: [{
-            shipping_address,
-            shipping_method
+            shipping_address
         }]
     } = basketData
 
@@ -26,8 +25,7 @@ export const parseShippingAddressFromBasket = (basketData) => {
             city: shipping_address.city,
             regionId: shipping_address.state_code,
             postcode: shipping_address.postal_code,
-            telephone: shipping_address.phone,
-            shipping_method: shipping_method ? shipping_method.id : undefined
+            telephone: shipping_address.phone
         }
     } else {
         initialValues = {

--- a/web/app/integration-manager/checkout/results.js
+++ b/web/app/integration-manager/checkout/results.js
@@ -59,6 +59,7 @@ export const receiveCheckoutConfirmationData = (confirmationData) => (dispatch, 
 }
 
 export const receiveUserEmail = createAction('Receive User Email Address', ['emailAddress'])
+export const receiveSelectedShippingMethod = createAction('Receive Selected Shipping Method', ['selectedShippingMethodId'])
 export const receiveLocationsCustomContent = createAction('Receive Locations Custom Content')
 export const receiveShippingAddressCustomContent = createAction('Receive Shipping Address Custom Content')
 export const receiveBillingAddressCustomContent = createAction('Receive Billing Address Custom Content')

--- a/web/app/store/checkout/reducer.js
+++ b/web/app/store/checkout/reducer.js
@@ -17,6 +17,7 @@ const checkoutReducer = handleActions({
     [integrationManagerResults.receiveCheckoutData]: mergePayload,
     [integrationManagerResults.receiveUserEmail]: mergePayload,
     [integrationManagerResults.receiveCheckoutCustomContent]: mergePayload,
+    [integrationManagerResults.receiveSelectedShippingMethod]: mergePayload,
     [integrationManagerResults.receiveLocationsCustomContent]: setCustomContent('locations'),
     [integrationManagerResults.receiveShippingAddressCustomContent]: setCustomContent('shippingAddress'),
     [integrationManagerResults.receiveBillingAddressCustomContent]: setCustomContent('billingAddress'),

--- a/web/app/store/checkout/shipping/selectors.js
+++ b/web/app/store/checkout/shipping/selectors.js
@@ -16,11 +16,15 @@ export const getSavedAddresses = createGetSelector(getCheckout, 'savedAddresses'
 
 export const getShippingAddress = createGetSelector(getCheckout, 'shippingAddress', Immutable.Map())
 
+export const getSelectedShippingMethodValue = createGetSelector(getCheckout, 'selectedShippingMethodId', '')
+
 export const getInitialShippingAddress = createSelector(
     getCheckout,
     getShippingAddress,
-    (checkout, address) => {
+    getSelectedShippingMethodValue,
+    (checkout, address, shippingMethodId) => {
         const savedAddressId = checkout.get('defaultShippingAddressId')
+        address = address.set('shippingMethodId', shippingMethodId)
         if (savedAddressId) {
             return address.set('saved_address', `${savedAddressId}`)
         }
@@ -28,7 +32,6 @@ export const getInitialShippingAddress = createSelector(
     }
 )
 
-export const getSelectedShippingMethodValue = createGetSelector(getShippingAddress, 'shipping_method', '')
 
 export const getSelectedShippingMethod = createSelector(
     getShippingMethods,


### PR DESCRIPTION
This PR moves the selected shipping method ID to be a child of the checkout state. It also renames the shipping method input to match out naming conventions (ie. no underscores).

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-69
 **Linked PRs**: n/a

## Changes
- renamed shipping method input
- added receiveSelectedShippingMethod to checkout reducer
- moved selected shipping method if out of the shippingAddress branch and into the checkout branch

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- add an item to the cart
- proceed through the checkout to the shipping page
- fill out the address form
- select a shipping method other than the default and submit the page
- check that the shipping method id is a child of the checkout branch in the redux store (and that no shipping method id is stored in shippingAddress)
- navigate back to the shipping page and confirm that the correct shipping method is still selected
- Preview the [SFCC Site](https://preview.mobify.com/?url=https%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- add an item to the cart
- proceed through the checkout to the shipping page
- fill out the address form
- select a shipping method other than the default and submit the page
- check that the shipping method id is a child of the checkout branch in the redux store (and that no shipping method id is stored in shippingAddress)
- navigate back to the shipping page and confirm that the correct shipping method is still selected
