### PR TITLE
Remove double download

### DIFF
--- a/web/app/integration-manager/_merlins-connector/app/commands.js
+++ b/web/app/integration-manager/_merlins-connector/app/commands.js
@@ -21,8 +21,25 @@ import {
     setLoggedIn
 } from '../../results'
 
-export const fetchPageData = (url) => (dispatch) => (
-    makeRequest(url)
+const requestCapturedDoc = () => {
+    return window.Progressive.capturedDocHTMLPromise.then((initialCapturedDocHTML) => {
+        const body = new Blob([initialCapturedDocHTML], {type: 'text/html'})
+        const capturedDocResponse = new Response(body, {
+            status: 200,
+            statusText: 'OK'
+        })
+
+        return Promise.resolve(capturedDocResponse)
+    })
+}
+
+let isInitialEntryToSite = true
+
+export const fetchPageData = (url) => (dispatch) => {
+    const request = isInitialEntryToSite ? requestCapturedDoc() : makeRequest(url)
+    isInitialEntryToSite = false
+
+    return request
         .then(jqueryResponse)
         .then((res) => {
             const [$, $response] = res
@@ -39,7 +56,7 @@ export const fetchPageData = (url) => (dispatch) => (
                 dispatch(setPageFetchError(error.message))
             }
         })
-)
+}
 
 export const initApp = () => (dispatch) => {
     // Use the pre-existing form_key if it already exists

--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -155,8 +155,8 @@ const attemptToInitializeApp = () => {
     }
 
     const triggerAppStartEvent = () => {
-        // Gather analytics information indicating loading is happening, so we can determine
-        // the % of people who don't make it to the pageview.
+        // Collect timing put for when app has started loading in order to
+        // determine % dropoff of users who don't make it to the "pageview" event.
         Sandy.init(window)
         Sandy.create(AJS_SLUG, 'auto') // eslint-disable-line no-undef
         const tracker = Sandy.trackers[Sandy.DEFAULT_TRACKER_NAME]


### PR DESCRIPTION
## Changes
- Uses HTML from the captured document on first load instead of re-fetching the page the user is already on. This helps to bring the overall load times down!

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Load the homepage
- Ensure that there isn't a second request for the homepage
