### PR TITLE
Hide the cart variants in cart product list

### DIFF
--- a/web/app/containers/cart/partials/cart-product-list.jsx
+++ b/web/app/containers/cart/partials/cart-product-list.jsx
@@ -83,8 +83,6 @@ class CartProductItem extends React.Component {
                 title={<h2 className="u-h5 u-text-family u-text-weight-semi-bold">{product.title}</h2>}
                 image={<ProductImage {...product.thumbnail} />}
                 >
-                <p className="u-color-neutral-50">Color: Maroon</p>
-                <p className="u-margin-bottom-sm u-color-neutral-50">Size: XL</p>
 
                 <FieldRow className="u-align-bottom">
                     <Field label="Quantity" idFor={`quantity-${cartItemId}`}>


### PR DESCRIPTION
# Hide the cart variants in cart product list

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-91
 **Linked PRs**: https://github.com/mobify/platform-scaffold/pull/669

## Changes
- Hide the cart variants in cart product list

**NOTE:** This will be _properly_ fixed on Merlin's & SFCC connectors post-launch of the IM. This is a temporary solution to hide the hard-coded variants.

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Add something to cart
- Ensure that in the cart product list, the variants don't show as `Maroon` and `XL`
