### PR TITLE
PDP 404 fixes & variant fallbacks

### DIFF
--- a/web/app/integration-manager/_sfcc-connector/parsers.js
+++ b/web/app/integration-manager/_sfcc-connector/parsers.js
@@ -54,7 +54,7 @@ export const parseProductDetails = ({id, name, price, inventory, long_descriptio
         available: inventory.orderable,
         thumbnail: images[0],
         images,
-        initialValues: variants ? setInitialVariantValues(variants, id, variation_attributes) : [],
+        initialValues: variants ? setInitialVariantValues(variants, id, variation_attributes) : {},
         variationCategories: variants ? parseVariationCategories(variation_attributes) : [],
         variants: variants ? variants.map(({product_id, variation_values}) => {
             return {
@@ -91,6 +91,8 @@ export const parseBasketContents = ({product_items, product_sub_total, product_t
         orderTotal: order_total
     }
 }
+
+/* eslint-enable camelcase */
 
 export const getCurrentProductID = (url) => {
     let productID

--- a/web/app/integration-manager/_sfcc-connector/parsers.js
+++ b/web/app/integration-manager/_sfcc-connector/parsers.js
@@ -42,12 +42,10 @@ const setInitialVariantValues = (variants, id, variationCategories) => {
 }
 
 
-
 export const getProductHref = (productID) => `/s/${getSiteID()}/${productID}.html`
 
 export const parseProductDetails = ({id, name, price, inventory, long_description, image_groups, variants, variation_attributes}) => {
     const images = parseImages(image_groups)
-
     return {
         id,
         title: name,

--- a/web/app/integration-manager/_sfcc-connector/parsers.js
+++ b/web/app/integration-manager/_sfcc-connector/parsers.js
@@ -46,11 +46,7 @@ const setInitialVariantValues = (variants, id, variationCategories) => {
 export const getProductHref = (productID) => `/s/${getSiteID()}/${productID}.html`
 
 export const parseProductDetails = ({id, name, price, inventory, long_description, image_groups, variants, variation_attributes}) => {
-    let images = []
-
-    if (image_groups) {
-        images = parseImages(image_groups)
-    }
+    const images = parseImages(image_groups)
 
     return {
         id,

--- a/web/app/integration-manager/_sfcc-connector/parsers.js
+++ b/web/app/integration-manager/_sfcc-connector/parsers.js
@@ -60,14 +60,14 @@ export const parseProductDetails = ({id, name, price, inventory, long_descriptio
         available: inventory.orderable,
         thumbnail: images[0],
         images,
-        initialValues: setInitialVariantValues(variants, id, variation_attributes),
-        variationCategories: parseVariationCategories(variation_attributes),
-        variants: variants.map(({product_id, variation_values}) => {
+        initialValues: variants ? setInitialVariantValues(variants, id, variation_attributes) : [],
+        variationCategories: variants ? parseVariationCategories(variation_attributes) : [],
+        variants: variants ? variants.map(({product_id, variation_values}) => {
             return {
                 id: product_id,
                 values: variation_values
             }
-        })
+        }) : []
     }
 }
 
@@ -101,7 +101,7 @@ export const parseBasketContents = ({product_items, product_sub_total, product_t
 export const getCurrentProductID = (url) => {
     let productID
 
-    let productIDMatch = /(\d+).html/.exec(url)
+    let productIDMatch = /\/([^/]+).html/.exec(url)
 
     if (productIDMatch) {
         productID = productIDMatch[1]

--- a/web/app/integration-manager/_sfcc-connector/parsers.js
+++ b/web/app/integration-manager/_sfcc-connector/parsers.js
@@ -41,12 +41,17 @@ const setInitialVariantValues = (variants, id, variationCategories) => {
     return defaultVariant
 }
 
-/* eslint-enable camelcase */
+
 
 export const getProductHref = (productID) => `/s/${getSiteID()}/${productID}.html`
 
 export const parseProductDetails = ({id, name, price, inventory, long_description, image_groups, variants, variation_attributes}) => {
-    const images = parseImages(image_groups)
+    let images = []
+
+    if (image_groups) {
+        images = parseImages(image_groups)
+    }
+
     return {
         id,
         title: name,
@@ -67,7 +72,6 @@ export const parseProductDetails = ({id, name, price, inventory, long_descriptio
 }
 
 export const parseBasketContents = ({product_items, product_sub_total, product_total, order_total}) => {
-    /* eslint-disable camelcase */
     let summary_count = 0
     const items = product_items ? product_items.map(({item_id, product_name, product_id, base_price, quantity}) => {
         summary_count += quantity

--- a/web/app/integration-manager/_sfcc-connector/products/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/products/commands.js
@@ -30,7 +30,6 @@ export const initProductDetailsPage = (url) => (dispatch) => {
 
             // since the pathname will always be master, the productHref will
             // only === pathname when landing on master page
-
             if (getProductHref(productDetailsData.id) === window.location.pathname && productDetailsData.variants) {
                 const {variants, initialValues} = productDetailsData
                 const defaultVariant = getInitialSelectedVariant(variants, initialValues)

--- a/web/app/integration-manager/_sfcc-connector/products/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/products/commands.js
@@ -30,7 +30,7 @@ export const initProductDetailsPage = (url) => (dispatch) => {
 
             // since the pathname will always be master, the productHref will
             // only === pathname when landing on master page
-            if (getProductHref(productDetailsData.id) === window.location.pathname && productDetailsData.variants) {
+            if (getProductHref(productDetailsData.id) === window.location.pathname && productDetailsData.variants.length) {
                 const {variants, initialValues} = productDetailsData
                 const defaultVariant = getInitialSelectedVariant(variants, initialValues)
                 const currentProductHref = defaultVariant.id

--- a/web/app/integration-manager/_sfcc-connector/products/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/products/commands.js
@@ -30,7 +30,8 @@ export const initProductDetailsPage = (url) => (dispatch) => {
 
             // since the pathname will always be master, the productHref will
             // only === pathname when landing on master page
-            if (getProductHref(productDetailsData.id) === window.location.pathname) {
+
+            if (getProductHref(productDetailsData.id) === window.location.pathname && productDetailsData.variants) {
                 const {variants, initialValues} = productDetailsData
                 const defaultVariant = getInitialSelectedVariant(variants, initialValues)
                 const currentProductHref = defaultVariant.id


### PR DESCRIPTION
Fix image filtering / PDP 404 errors

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-104

## Changes
- Fix PDP productID regex
- add checks for if variants are present or not 

## How to test-drive this PR
- Use sfcc connector
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Try navigating to men -> unisex gloves, or grand theft auto under electronics, and ensure the API request doesn't 404 and that you can proceed with checkout
