### PR TITLE
Update sfcc connector storage

### DIFF
--- a/web/app/integration-manager/_sfcc-connector/utils.js
+++ b/web/app/integration-manager/_sfcc-connector/utils.js
@@ -69,24 +69,24 @@ const removeItemFromBrowserStorage = (keyName) => {
 
 export const storeAuthToken = (authorization) => {
     if (authorization) {
-        window.sessionStorage.setItem(AUTH_KEY_NAME, authorization)
+        setItemInBrowserStorage(AUTH_KEY_NAME, authorization)
     }
 }
 
 export const getAuthToken = () => {
-    return window.sessionStorage.getItem(AUTH_KEY_NAME)
+    return getItemFromBrowserStorage(AUTH_KEY_NAME)
 }
 
 export const deleteAuthToken = () => {
-    window.sessionStorage.removeItem(AUTH_KEY_NAME)
+    removeItemFromBrowserStorage(AUTH_KEY_NAME)
 }
 
 export const deleteBasketID = () => {
-    window.sessionStorage.removeItem(BASKET_KEY_NAME)
+    removeItemFromBrowserStorage(BASKET_KEY_NAME)
 }
 
 export const getBasketID = () => {
-    return window.sessionStorage.getItem(BASKET_KEY_NAME)
+    return getItemFromBrowserStorage(BASKET_KEY_NAME)
 }
 
 export const storeBasketID = (basketID) => {
@@ -94,7 +94,7 @@ export const storeBasketID = (basketID) => {
         throw new Error('Storing basketID that is undefined!!')
     }
 
-    window.sessionStorage.setItem(BASKET_KEY_NAME, basketID)
+    setItemInBrowserStorage(BASKET_KEY_NAME, basketID)
 }
 
 export const getAuthTokenPayload = (authToken) => {

--- a/web/app/integration-manager/_sfcc-connector/utils.js
+++ b/web/app/integration-manager/_sfcc-connector/utils.js
@@ -40,6 +40,33 @@ const supportsSessionStorage = () => {
     }
     return cachedSessionStorageSupport
 }
+
+const setItemInBrowserStorage = (keyName, value) => {
+    // Use session storage if it's supported
+    if (supportsSessionStorage()) {
+        window.sessionStorage.setItem(keyName, value)
+    } else {
+        // Use Cookies otherwise
+        setCookieValue(keyName, value)
+    }
+}
+
+const getItemFromBrowserStorage = (keyName) => {
+    if (supportsSessionStorage()) {
+        return window.sessionStorage.getItem(keyName)
+    }
+
+    return getCookieValue(keyName)
+}
+
+const removeItemFromBrowserStorage = (keyName) => {
+    if (supportsSessionStorage()) {
+        window.sessionStorage.removeItem(keyName)
+    } else {
+        removeCookieValue(keyName)
+    }
+}
+
 export const storeAuthToken = (authorization) => {
     if (authorization) {
         window.sessionStorage.setItem(AUTH_KEY_NAME, authorization)

--- a/web/app/integration-manager/_sfcc-connector/utils.js
+++ b/web/app/integration-manager/_sfcc-connector/utils.js
@@ -8,6 +8,21 @@ import {getApiEndPoint, getRequestHeaders} from './config'
 const AUTH_KEY_NAME = 'mob-auth'
 const BASKET_KEY_NAME = 'mob-basket'
 
+const setCookieValue = (keyName, value) => {
+    document.cookie = `${keyName}=${value}`
+}
+
+const getCookieValue = (keyName) => {
+    const cookieRegex = new RegExp(`${keyName}=([^;]+);`)
+    const cookieMatch = cookieRegex.exec(document.cookie)
+
+    return cookieMatch ? cookieMatch[1] : ''
+}
+
+const removeCookieValue = (keyName) => {
+    document.cookie = `${keyName}=; expires=Thu, 01 Jan 1970 00:00:01 GMT;`
+}
+
 // sessionStorage detection as seen in such great libraries as Modernizr
 // https://github.com/Modernizr/Modernizr/blob/master/feature-detects/storage/sessionstorage.js
 let cachedSessionStorageSupport

--- a/web/app/integration-manager/_sfcc-connector/utils.js
+++ b/web/app/integration-manager/_sfcc-connector/utils.js
@@ -8,6 +8,23 @@ import {getApiEndPoint, getRequestHeaders} from './config'
 const AUTH_KEY_NAME = 'mob-auth'
 const BASKET_KEY_NAME = 'mob-basket'
 
+// sessionStorage detection as seen in such great libraries as Modernizr
+// https://github.com/Modernizr/Modernizr/blob/master/feature-detects/storage/sessionstorage.js
+let cachedSessionStorageSupport
+const supportsSessionStorage = () => {
+    if (cachedSessionStorageSupport !== undefined) {
+        return cachedSessionStorageSupport
+    }
+    const mod = 'modernizr'
+    try {
+        sessionStorage.setItem(mod, mod)
+        sessionStorage.removeItem(mod)
+        cachedSessionStorageSupport = true
+    } catch (e) {
+        cachedSessionStorageSupport = false
+    }
+    return cachedSessionStorageSupport
+}
 export const storeAuthToken = (authorization) => {
     if (authorization) {
         window.sessionStorage.setItem(AUTH_KEY_NAME, authorization)


### PR DESCRIPTION
Not all browsers support sessionStorage. This PR adds a function to check if session storage is supported and if it's not use cookies instead to track SFCC auth and basket data. 

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-98
 **Linked PRs**: n/a

## Changes
- Added function to check if sessionStorage is supported
- Replace calls to set/get/remove from sessionStorage with function that will use cookies if sessionStorage is unsupported

## How to test-drive this PR
- Run `npm run dev`
- Preview [SFCC site](https://preview.mobify.com/?url=https%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1) in a private Safari window
- Navigate through the site and confirm it works correctly (auth & basket data will be stored in cookies)
-  Preview [SFCC site](https://preview.mobify.com/?url=https%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1) again but in a regular chrome window
- Navigate through the site and confirm is works correctly (auth & basket data will be stored in sessionStorage) 

