### PR TITLE
Add Stub Connector

### DIFF
--- a/web/app/containers/navigation/container.jsx
+++ b/web/app/containers/navigation/container.jsx
@@ -61,28 +61,30 @@ const Navigation = (props) => {
 
     return (
         <Sheet className="t-navigation" open={isOpen} onDismiss={closeNavigation} maskOpacity={0.7} coverage="85%">
-            <Nav root={root.title ? root : null} path={path} onPathChange={onPathChange}>
-                <HeaderBar>
-                    <HeaderBarTitle className="u-flex u-padding-start u-text-align-start">
-                        <h2 className="u-text-family-header u-text-uppercase">
-                            <span className="u-text-weight-extra-light">Menu</span>
-                        </h2>
-                    </HeaderBarTitle>
+            {path &&
+                <Nav root={root.title ? root : null} path={path} onPathChange={onPathChange}>
+                    <HeaderBar>
+                        <HeaderBarTitle className="u-flex u-padding-start u-text-align-start">
+                            <h2 className="u-text-family-header u-text-uppercase">
+                                <span className="u-text-weight-extra-light">Menu</span>
+                            </h2>
+                        </HeaderBarTitle>
 
-                    <HeaderBarActions>
-                        <IconLabelButton iconName="close" label="close" onClick={closeNavigation} />
-                    </HeaderBarActions>
-                </HeaderBar>
+                        <HeaderBarActions>
+                            <IconLabelButton iconName="close" label="close" onClick={closeNavigation} />
+                        </HeaderBarActions>
+                    </HeaderBar>
 
-                <NavMenu itemFactory={itemFactory} />
+                    <NavMenu itemFactory={itemFactory} />
 
-                <div>
-                    <NavigationSocialIcons />
-                    <div className="t-navigation__copyright u-padding-md">
-                        <p>© 2017 Mobify Research & Development Inc. All rights reserved.</p>
+                    <div>
+                        <NavigationSocialIcons />
+                        <div className="t-navigation__copyright u-padding-md">
+                            <p>© 2017 Mobify Research & Development Inc. All rights reserved.</p>
+                        </div>
                     </div>
-                </div>
-            </Nav>
+                </Nav>
+            }
         </Sheet>
     )
 }

--- a/web/app/integration-manager/_stub-connector/README.md
+++ b/web/app/integration-manager/_stub-connector/README.md
@@ -1,2 +1,2 @@
 # Mobify Stub Connector
-- The purpose of this connector is to be a starting place for building a new custom connector
+This connector is intended to be a starting place for building a new custom connector. It contains stubs for all of the commands the Integration Manager expects. To use this connector, replace the stubs with functions that work with your back end system. 

--- a/web/app/integration-manager/_stub-connector/README.md
+++ b/web/app/integration-manager/_stub-connector/README.md
@@ -1,2 +1,4 @@
 # Mobify Stub Connector
-This connector is intended to be a starting place for building a new custom connector. It contains stubs for all of the commands the Integration Manager expects. To use this connector, replace the stubs with functions that work with your back end system. 
+This connector is intended to be a starting place for building a new custom connector. It contains stubs for all of the `commands` the Integration Manager expects. For some `commands`, it also dispatches the associated `results` with example data.
+
+To use this connector, replace the stubs with functions that work with your back end system. 

--- a/web/app/integration-manager/_stub-connector/README.md
+++ b/web/app/integration-manager/_stub-connector/README.md
@@ -1,0 +1,2 @@
+# Mobify Stub Connector
+- The purpose of this connector is to be a starting place for building a new custom connector

--- a/web/app/integration-manager/_stub-connector/account/commands.js
+++ b/web/app/integration-manager/_stub-connector/account/commands.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+
 export const initLoginPage = (url, routeName) => (dispatch) => {
     console.log('[Stub Connector] Called initLoginPage stub')
     return Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/account/commands.js
+++ b/web/app/integration-manager/_stub-connector/account/commands.js
@@ -1,0 +1,15 @@
+export const initLoginPage = (url, routeName) => (dispatch) => Promise.resolve()
+
+export const initRegisterPage = (url, routeName) => (dispatch) => Promise.resolve()
+
+export const navigateToSection = (router, routes, sectionName) => (dispatch) => Promise.resolve()
+
+export const login = (username, password, rememberMe) => (dispatch) => Promise.resolve()
+
+export const logout = () => (dispatch) => Promise.resolve()
+
+export const registerUser = (firstname, lastname, email, password) => (dispatch) => Promise.resolve()
+
+export const updateShippingAddress = (formValues) => (dispatch) => Promise.resolve()
+
+export const updateBillingAddress = (formValues) => (dispatch) => Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/account/commands.js
+++ b/web/app/integration-manager/_stub-connector/account/commands.js
@@ -1,3 +1,7 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
 /* eslint-disable no-unused-vars */
 
 export const initLoginPage = (url, routeName) => (dispatch) => {

--- a/web/app/integration-manager/_stub-connector/account/commands.js
+++ b/web/app/integration-manager/_stub-connector/account/commands.js
@@ -1,15 +1,39 @@
-export const initLoginPage = (url, routeName) => (dispatch) => Promise.resolve()
+export const initLoginPage = (url, routeName) => (dispatch) => {
+    console.log('[Stub Connector] Called initLoginPage stub')
+    return Promise.resolve()
+}
 
-export const initRegisterPage = (url, routeName) => (dispatch) => Promise.resolve()
+export const initRegisterPage = (url, routeName) => (dispatch) => {
+    console.log('[Stub Connector] Called initRegisterPage stub')
+    return Promise.resolve()
+}
 
-export const navigateToSection = (router, routes, sectionName) => (dispatch) => Promise.resolve()
+export const navigateToSection = (router, routes, sectionName) => (dispatch) => {
+    console.log('[Stub Connector] Called navigateToSection stub')
+    return Promise.resolve()
+}
 
-export const login = (username, password, rememberMe) => (dispatch) => Promise.resolve()
+export const login = (username, password, rememberMe) => (dispatch) => {
+    console.log('[Stub Connector] Called login stub')
+    return Promise.resolve()
+}
 
-export const logout = () => (dispatch) => Promise.resolve()
+export const logout = () => (dispatch) => {
+    console.log('[Stub Connector] Called logout stub')
+    return Promise.resolve()
+}
 
-export const registerUser = (firstname, lastname, email, password) => (dispatch) => Promise.resolve()
+export const registerUser = (firstname, lastname, email, password) => (dispatch) => {
+    console.log('[Stub Connector] Called registerUser stub')
+    return Promise.resolve()
+}
 
-export const updateShippingAddress = (formValues) => (dispatch) => Promise.resolve()
+export const updateShippingAddress = (formValues) => (dispatch) => {
+    console.log('[Stub Connector] Called updateShippingAddress stub')
+    return Promise.resolve()
+}
 
-export const updateBillingAddress = (formValues) => (dispatch) => Promise.resolve()
+export const updateBillingAddress = (formValues) => (dispatch) => {
+    console.log('[Stub Connector] Called updateBillingAddress stub')
+    return Promise.resolve()
+}

--- a/web/app/integration-manager/_stub-connector/actions.js
+++ b/web/app/integration-manager/_stub-connector/actions.js
@@ -9,3 +9,5 @@ import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
 // by the app should go into ./results.js
 
 export const exampleAction = createAction('Some project-specific action')
+
+export const receiveFormInfo = createAction('Receive Form Info')

--- a/web/app/integration-manager/_stub-connector/actions.js
+++ b/web/app/integration-manager/_stub-connector/actions.js
@@ -1,0 +1,11 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
+import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
+
+// Add other actions here that are specific to this connector.
+// Actions that are returned out of the connector and reduced
+// by the app should go into ./results.js
+
+export const exampleAction = createAction('Some project-specific action')

--- a/web/app/integration-manager/_stub-connector/actions.js
+++ b/web/app/integration-manager/_stub-connector/actions.js
@@ -8,6 +8,6 @@ import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
 // Actions that are returned out of the connector and reduced
 // by the app should go into ./results.js
 
-export const exampleAction = createAction('Some project-specific action')
+export const exampleAction = createAction('Some connector-specific action')
 
 export const receiveFormInfo = createAction('Receive Form Info')

--- a/web/app/integration-manager/_stub-connector/app/commands.js
+++ b/web/app/integration-manager/_stub-connector/app/commands.js
@@ -2,7 +2,8 @@ import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
 import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 
 import {
-    setPageFetchError
+    setPageFetchError,
+    receiveNavigationData
 } from '../../results'
 
 /**
@@ -51,4 +52,29 @@ export const fetchPageData = (url) => (dispatch) => {
         })
 }
 
-export const initApp = () => (dispatch) => Promise.resolve()
+export const initApp = () => (dispatch) => {
+    const exampleNavigationData = {
+        path: '/',
+        root: {
+            title: 'Root',
+            path: '/',
+            children: [{
+                title: 'Category 1',
+                path: '/potions.html'
+            }, {
+                title: 'Category 2',
+                path: '/books.html'
+            }, {
+                title: 'Category 3',
+                path: '/ingredients.html'
+            }]
+        }
+    }
+
+    return new Promise((resolve) => {
+        // For more information on the shape of the expected data,
+        // see https://docs.mobify.com/progressive-web/latest/components/#!/Nav
+        dispatch(receiveNavigationData(exampleNavigationData))
+        resolve()
+    })
+}

--- a/web/app/integration-manager/_stub-connector/app/commands.js
+++ b/web/app/integration-manager/_stub-connector/app/commands.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+
 import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
 import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 

--- a/web/app/integration-manager/_stub-connector/app/commands.js
+++ b/web/app/integration-manager/_stub-connector/app/commands.js
@@ -1,9 +1,12 @@
 import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
 import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 
+import {getCart} from '../cart/commands'
+
 import {
     setPageFetchError,
-    receiveNavigationData
+    receiveNavigationData,
+    setCartURL
 } from '../../results'
 
 /**
@@ -75,6 +78,8 @@ export const initApp = () => (dispatch) => {
         // For more information on the shape of the expected data,
         // see https://docs.mobify.com/progressive-web/latest/components/#!/Nav
         dispatch(receiveNavigationData(exampleNavigationData))
+        dispatch(getCart())
+        dispatch(setCartURL('/checkout/cart/'))
         resolve()
     })
 }

--- a/web/app/integration-manager/_stub-connector/app/commands.js
+++ b/web/app/integration-manager/_stub-connector/app/commands.js
@@ -1,1 +1,45 @@
+import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
+import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
+
+import {
+    setPageFetchError
+} from '../../results'
+
+const requestCapturedDoc = () => {
+    return window.Progressive.capturedDocHTMLPromise.then((initialCapturedDocHTML) => {
+        const body = new Blob([initialCapturedDocHTML], {type: 'text/html'})
+        const capturedDocResponse = new Response(body, {
+            status: 200,
+            statusText: 'OK'
+        })
+
+        return Promise.resolve(capturedDocResponse)
+    })
+}
+
+let isInitialEntryToSite = true
+
+export const fetchPageData = (url) => (dispatch) => {
+    const request = isInitialEntryToSite ? requestCapturedDoc() : makeRequest(url)
+    isInitialEntryToSite = false
+
+    return request
+        .then(jqueryResponse)
+        .then((res) => {
+            const [$, $response] = res
+
+            // Add global actions here
+
+            return res
+        })
+        .catch((error) => {
+            console.info(error.message)
+            if (error.name !== 'FetchError') {
+                throw error
+            } else {
+                dispatch(setPageFetchError(error.message))
+            }
+        })
+}
+
 export const initApp = () => (dispatch) => Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/app/commands.js
+++ b/web/app/integration-manager/_stub-connector/app/commands.js
@@ -19,6 +19,9 @@ const requestCapturedDoc = () => {
 
 let isInitialEntryToSite = true
 
+/**
+ * This function is used to fetch data from a desktop page
+ */
 export const fetchPageData = (url) => (dispatch) => {
     const request = isInitialEntryToSite ? requestCapturedDoc() : makeRequest(url)
     isInitialEntryToSite = false

--- a/web/app/integration-manager/_stub-connector/app/commands.js
+++ b/web/app/integration-manager/_stub-connector/app/commands.js
@@ -1,0 +1,1 @@
+export const initApp = () => (dispatch) => Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/app/commands.js
+++ b/web/app/integration-manager/_stub-connector/app/commands.js
@@ -5,6 +5,11 @@ import {
     setPageFetchError
 } from '../../results'
 
+/**
+ * When the user first lands on the site, the response from the desktop site is saved
+ * This function allows you to get that response
+ * You will only need to use this function if you're using HTML scraping as your back end
+ */
 const requestCapturedDoc = () => {
     return window.Progressive.capturedDocHTMLPromise.then((initialCapturedDocHTML) => {
         const body = new Blob([initialCapturedDocHTML], {type: 'text/html'})
@@ -21,6 +26,7 @@ let isInitialEntryToSite = true
 
 /**
  * This function is used to fetch data from a desktop page
+ * You will only need to use this function if you're using HTML scraping as your back end
  */
 export const fetchPageData = (url) => (dispatch) => {
     const request = isInitialEntryToSite ? requestCapturedDoc() : makeRequest(url)

--- a/web/app/integration-manager/_stub-connector/app/commands.js
+++ b/web/app/integration-manager/_stub-connector/app/commands.js
@@ -74,12 +74,10 @@ export const initApp = () => (dispatch) => {
         }
     }
 
-    return new Promise((resolve) => {
-        // For more information on the shape of the expected data,
-        // see https://docs.mobify.com/progressive-web/latest/components/#!/Nav
-        dispatch(receiveNavigationData(exampleNavigationData))
-        dispatch(getCart())
-        dispatch(setCartURL('/checkout/cart/'))
-        resolve()
-    })
+    // For more information on the shape of the expected data,
+    // see https://docs.mobify.com/progressive-web/latest/components/#!/Nav
+    dispatch(receiveNavigationData(exampleNavigationData))
+    dispatch(getCart())
+    dispatch(setCartURL('/checkout/cart/'))
+    return Promise.resolve()
 }

--- a/web/app/integration-manager/_stub-connector/app/commands.js
+++ b/web/app/integration-manager/_stub-connector/app/commands.js
@@ -56,6 +56,8 @@ export const fetchPageData = (url) => (dispatch) => {
 }
 
 export const initApp = () => (dispatch) => {
+    console.log('[Stub Connector] Called initApp stub')
+
     const exampleNavigationData = {
         path: '/',
         root: {

--- a/web/app/integration-manager/_stub-connector/app/commands.js
+++ b/web/app/integration-manager/_stub-connector/app/commands.js
@@ -1,3 +1,7 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
 /* eslint-disable no-unused-vars */
 
 import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'

--- a/web/app/integration-manager/_stub-connector/cart/commands.js
+++ b/web/app/integration-manager/_stub-connector/cart/commands.js
@@ -1,6 +1,45 @@
+import {receiveCartContents, receiveCartTotals} from '../../cart/results'
+import {receiveCartProductData} from '../../products/results'
+
 export const initCartPage = (url, routeName) => (dispatch) => Promise.resolve()
 
-export const getCart = () => (dispatch) => Promise.resolve()
+export const getCart = () => (dispatch) => {
+    const exampleCartData = {
+        items: [{
+            id: '1',
+            productId: '1',
+            href: '/product1.html',
+            quantity: 1,
+            itemPrice: '$10.00',
+            linePrice: '$10.00'
+        }],
+        subtotal: '$10.00',
+        orderTotal: '$10.00'
+    }
+
+    const image = {
+        src: '//via.placeholder.com/350x350',
+        alt: 'Product 1'
+    }
+    const exampleCartProducts = {
+        ['/product1.html']: {
+            price: '$10.00',
+            available: true,
+            href: '/product1.html',
+            thumbnail: image,
+            title: 'Product 1',
+            id: '1',
+            description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+        }
+    }
+
+    return new Promise((resolve) => {
+        // For more information on the shape of the expected data, see ../../cart/types
+        dispatch(receiveCartContents(exampleCartData))
+        dispatch(receiveCartProductData(exampleCartProducts))
+        resolve()
+    })
+}
 
 export const addToCart = (productId, quantity) => (dispatch) => Promise.resolve()
 

--- a/web/app/integration-manager/_stub-connector/cart/commands.js
+++ b/web/app/integration-manager/_stub-connector/cart/commands.js
@@ -1,3 +1,7 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
 /* eslint-disable no-unused-vars */
 
 import {receiveCartContents} from '../../cart/results'

--- a/web/app/integration-manager/_stub-connector/cart/commands.js
+++ b/web/app/integration-manager/_stub-connector/cart/commands.js
@@ -1,0 +1,17 @@
+export const initCartPage = (url, routeName) => (dispatch) => Promise.resolve()
+
+export const getCart = () => (dispatch) => Promise.resolve()
+
+export const addToCart = (productId, quantity) => (dispatch) => Promise.resolve()
+
+export const removeFromCart = (itemID) => (dispatch) => Promise.resolve()
+
+export const updateItemQuantity = (itemID, quantity) => (dispatch) => Promise.resolve()
+
+export const addToWishlist = (productId, productURL) => (dispatch) => Promise.resolve()
+
+export const fetchTaxEstimate = (address, shippingMethod) => (dispatch) => Promise.resolve()
+
+export const putPromoCode = (couponCode) => (dispatch) => Promise.resolve()
+
+export const deletePromoCode = (couponCode) => (dispatch) => Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/cart/commands.js
+++ b/web/app/integration-manager/_stub-connector/cart/commands.js
@@ -33,12 +33,10 @@ export const getCart = () => (dispatch) => {
         }
     }
 
-    return new Promise((resolve) => {
-        // For more information on the shape of the expected data, see ../../cart/types
-        dispatch(receiveCartContents(exampleCartData))
-        dispatch(receiveCartProductData(exampleCartProducts))
-        resolve()
-    })
+    // For more information on the shape of the expected data, see ../../cart/types
+    dispatch(receiveCartContents(exampleCartData))
+    dispatch(receiveCartProductData(exampleCartProducts))
+    return Promise.resolve()
 }
 
 export const addToCart = (productId, quantity) => (dispatch) => Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/cart/commands.js
+++ b/web/app/integration-manager/_stub-connector/cart/commands.js
@@ -1,4 +1,6 @@
-import {receiveCartContents, receiveCartTotals} from '../../cart/results'
+/* eslint-disable no-unused-vars */
+
+import {receiveCartContents} from '../../cart/results'
 import {receiveCartProductData} from '../../products/results'
 
 export const initCartPage = (url, routeName) => (dispatch) => {
@@ -8,7 +10,7 @@ export const initCartPage = (url, routeName) => (dispatch) => {
 
 export const getCart = () => (dispatch) => {
     console.log('[Stub Connector] Called getCart stub')
-    
+
     const exampleCartData = {
         items: [{
             id: '1',
@@ -27,7 +29,7 @@ export const getCart = () => (dispatch) => {
         alt: 'Product 1'
     }
     const exampleCartProducts = {
-        ['/product1.html']: {
+        '/product1.html': {
             price: '$10.00',
             available: true,
             href: '/product1.html',

--- a/web/app/integration-manager/_stub-connector/cart/commands.js
+++ b/web/app/integration-manager/_stub-connector/cart/commands.js
@@ -1,9 +1,14 @@
 import {receiveCartContents, receiveCartTotals} from '../../cart/results'
 import {receiveCartProductData} from '../../products/results'
 
-export const initCartPage = (url, routeName) => (dispatch) => Promise.resolve()
+export const initCartPage = (url, routeName) => (dispatch) => {
+    console.log('[Stub Connector] Called initCartPage stub')
+    return Promise.resolve()
+}
 
 export const getCart = () => (dispatch) => {
+    console.log('[Stub Connector] Called getCart stub')
+    
     const exampleCartData = {
         items: [{
             id: '1',
@@ -39,16 +44,37 @@ export const getCart = () => (dispatch) => {
     return Promise.resolve()
 }
 
-export const addToCart = (productId, quantity) => (dispatch) => Promise.resolve()
+export const addToCart = (productId, quantity) => (dispatch) => {
+    console.log('[Stub Connector] Called addToCart stub')
+    return Promise.resolve()
+}
 
-export const removeFromCart = (itemID) => (dispatch) => Promise.resolve()
+export const removeFromCart = (itemID) => (dispatch) => {
+    console.log('[Stub Connector] Called removeFromCart stub')
+    return Promise.resolve()
+}
 
-export const updateItemQuantity = (itemID, quantity) => (dispatch) => Promise.resolve()
+export const updateItemQuantity = (itemID, quantity) => (dispatch) => {
+    console.log('[Stub Connector] Called updateItemQuantity stub')
+    return Promise.resolve()
+}
 
-export const addToWishlist = (productId, productURL) => (dispatch) => Promise.resolve()
+export const addToWishlist = (productId, productURL) => (dispatch) => {
+    console.log('[Stub Connector] Called addToWishlist stub')
+    return Promise.resolve()
+}
 
-export const fetchTaxEstimate = (address, shippingMethod) => (dispatch) => Promise.resolve()
+export const fetchTaxEstimate = (address, shippingMethod) => (dispatch) => {
+    console.log('[Stub Connector] Called fetchTaxEstimate stub')
+    return Promise.resolve()
+}
 
-export const putPromoCode = (couponCode) => (dispatch) => Promise.resolve()
+export const putPromoCode = (couponCode) => (dispatch) => {
+    console.log('[Stub Connector] Called putPromoCode stub')
+    return Promise.resolve()
+}
 
-export const deletePromoCode = (couponCode) => (dispatch) => Promise.resolve()
+export const deletePromoCode = (couponCode) => (dispatch) => {
+    console.log('[Stub Connector] Called deletePromoCode stub')
+    return Promise.resolve()
+}

--- a/web/app/integration-manager/_stub-connector/categories/commands.js
+++ b/web/app/integration-manager/_stub-connector/categories/commands.js
@@ -3,6 +3,8 @@ import {receiveProductListProductData} from '../../products/results'
 import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 
 export const initProductListPage = (url, routeName) => (dispatch) => {
+    console.log('[Stub Connector] Called initProductListPage stub')
+    
     const thumbnail = {
         src: '//via.placeholder.com/350x350',
         alt: 'Product Image'

--- a/web/app/integration-manager/_stub-connector/categories/commands.js
+++ b/web/app/integration-manager/_stub-connector/categories/commands.js
@@ -1,1 +1,51 @@
-export const initProductListPage = (url, routeName) => (dispatch) => Promise.resolve()
+import {receiveCategoryContents, receiveCategoryInformation} from '../../categories/results'
+import {receiveProductListProductData} from '../../products/results'
+import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
+
+export const initProductListPage = (url, routeName) => (dispatch) => {
+    const thumbnail = {src: '//via.placeholder.com/120x150'}
+    const sharedData = {
+        price: '$10.00',
+        available: true,
+        images: [thumbnail],
+        thumbnail
+    }
+
+    const exampleProductData = {
+        '/product1.html': {
+            id: '1',
+            title: 'Product 1',
+            href: '/product1.html',
+            ...sharedData
+        },
+        '/product2.html': {
+            id: '2',
+            title: 'Product 2',
+            href: '/product2.html',
+            ...sharedData
+        },
+        '/product3.html': {
+            id: '3',
+            title: 'Product 3',
+            href: '/product3.html',
+            ...sharedData
+        }
+    }
+
+    const exampleCategoryData = {
+        itemCount: 3,
+        products: [
+            '/product1.html',
+            '/product2.html',
+            '/product3.html'
+        ]
+    }
+
+    const pathKey = urlToPathKey(url)
+
+    return new Promise((resolve) => {
+        dispatch(receiveProductListProductData(exampleProductData))
+        dispatch(receiveCategoryContents(pathKey, exampleCategoryData))
+        resolve()
+    })
+}

--- a/web/app/integration-manager/_stub-connector/categories/commands.js
+++ b/web/app/integration-manager/_stub-connector/categories/commands.js
@@ -47,11 +47,9 @@ export const initProductListPage = (url, routeName) => (dispatch) => {
 
     const pathKey = urlToPathKey(url)
 
-    return new Promise((resolve) => {
-        // For more information on the shape of the expected data, see ../../products/types
-        dispatch(receiveProductListProductData(exampleProductData))
-        // For more information on the shape of the expected data, see ../../categories/types
-        dispatch(receiveCategoryContents(pathKey, exampleCategoryData))
-        resolve()
-    })
+    // For more information on the shape of the expected data, see ../../products/types
+    dispatch(receiveProductListProductData(exampleProductData))
+    // For more information on the shape of the expected data, see ../../categories/types
+    dispatch(receiveCategoryContents(pathKey, exampleCategoryData))
+    return Promise.resolve()
 }

--- a/web/app/integration-manager/_stub-connector/categories/commands.js
+++ b/web/app/integration-manager/_stub-connector/categories/commands.js
@@ -1,3 +1,7 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
 /* eslint-disable no-unused-vars */
 
 import {receiveCategoryContents} from '../../categories/results'

--- a/web/app/integration-manager/_stub-connector/categories/commands.js
+++ b/web/app/integration-manager/_stub-connector/categories/commands.js
@@ -1,10 +1,12 @@
+/* eslint-disable no-unused-vars */
+
 import {receiveCategoryContents} from '../../categories/results'
 import {receiveProductListProductData} from '../../products/results'
 import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 
 export const initProductListPage = (url, routeName) => (dispatch) => {
     console.log('[Stub Connector] Called initProductListPage stub')
-    
+
     const thumbnail = {
         src: '//via.placeholder.com/350x350',
         alt: 'Product Image'

--- a/web/app/integration-manager/_stub-connector/categories/commands.js
+++ b/web/app/integration-manager/_stub-connector/categories/commands.js
@@ -1,9 +1,13 @@
-import {receiveCategoryContents, receiveCategoryInformation} from '../../categories/results'
+import {receiveCategoryContents} from '../../categories/results'
 import {receiveProductListProductData} from '../../products/results'
 import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 
 export const initProductListPage = (url, routeName) => (dispatch) => {
-    const thumbnail = {src: '//via.placeholder.com/120x150'}
+    const thumbnail = {
+        src: '//via.placeholder.com/350x350',
+        alt: 'Product Image'
+    }
+
     const sharedData = {
         price: '$10.00',
         available: true,
@@ -44,7 +48,9 @@ export const initProductListPage = (url, routeName) => (dispatch) => {
     const pathKey = urlToPathKey(url)
 
     return new Promise((resolve) => {
+        // For more information on the shape of the expected data, see ../../products/types
         dispatch(receiveProductListProductData(exampleProductData))
+        // For more information on the shape of the expected data, see ../../categories/types
         dispatch(receiveCategoryContents(pathKey, exampleCategoryData))
         resolve()
     })

--- a/web/app/integration-manager/_stub-connector/categories/commands.js
+++ b/web/app/integration-manager/_stub-connector/categories/commands.js
@@ -1,0 +1,1 @@
+export const initProductListPage = (url, routeName) => (dispatch) => Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/checkout/commands.js
+++ b/web/app/integration-manager/_stub-connector/checkout/commands.js
@@ -1,3 +1,7 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
 /* eslint-disable no-unused-vars */
 
 export const initCheckoutShippingPage = (url) => (dispatch) => {

--- a/web/app/integration-manager/_stub-connector/checkout/commands.js
+++ b/web/app/integration-manager/_stub-connector/checkout/commands.js
@@ -1,0 +1,15 @@
+export const initCheckoutShippingPage = (url) => (dispatch) => Promise.resolve()
+
+export const initCheckoutPaymentPage = (url) => (dispatch) => Promise.resolve()
+
+export const initCheckoutConfirmationPage = (url) => (dispatch) => Promise.resolve()
+
+export const submitShipping = (formValues) => (dispatch) => Promise.resolve()
+
+export const submitPayment = (formValues) => (dispatch) => Promise.resolve()
+
+export const fetchShippingMethodsEstimate = (formName) => (dispatch) => Promise.resolve()
+
+export const updateShippingAndBilling = () => (dispatch) => Promise.resolve()
+
+export const fetchSavedShippingAddresses = () => (dispatch) => Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/checkout/commands.js
+++ b/web/app/integration-manager/_stub-connector/checkout/commands.js
@@ -1,15 +1,39 @@
-export const initCheckoutShippingPage = (url) => (dispatch) => Promise.resolve()
+export const initCheckoutShippingPage = (url) => (dispatch) => {
+    console.log('[Stub Connector] Called initCheckoutShippingPage stub')
+    return Promise.resolve()
+}
 
-export const initCheckoutPaymentPage = (url) => (dispatch) => Promise.resolve()
+export const initCheckoutPaymentPage = (url) => (dispatch) => {
+    console.log('[Stub Connector] Called initCheckoutPaymentPage stub')
+    return Promise.resolve()
+}
 
-export const initCheckoutConfirmationPage = (url) => (dispatch) => Promise.resolve()
+export const initCheckoutConfirmationPage = (url) => (dispatch) => {
+    console.log('[Stub Connector] Called initCheckoutConfirmationPage stub')
+    return Promise.resolve()
+}
 
-export const submitShipping = (formValues) => (dispatch) => Promise.resolve()
+export const submitShipping = (formValues) => (dispatch) => {
+    console.log('[Stub Connector] Called submitShipping stub')
+    return Promise.resolve()
+}
 
-export const submitPayment = (formValues) => (dispatch) => Promise.resolve()
+export const submitPayment = (formValues) => (dispatch) => {
+    console.log('[Stub Connector] Called submitPayment stub')
+    return Promise.resolve()
+}
 
-export const fetchShippingMethodsEstimate = (formName) => (dispatch) => Promise.resolve()
+export const fetchShippingMethodsEstimate = (formName) => (dispatch) => {
+    console.log('[Stub Connector] Called fetchShippingMethodsEstimate stub')
+    return Promise.resolve()
+}
 
-export const updateShippingAndBilling = () => (dispatch) => Promise.resolve()
+export const updateShippingAndBilling = () => (dispatch) => {
+    console.log('[Stub Connector] Called updateShippingAndBilling stub')
+    return Promise.resolve()
+}
 
-export const fetchSavedShippingAddresses = () => (dispatch) => Promise.resolve()
+export const fetchSavedShippingAddresses = () => (dispatch) => {
+    console.log('[Stub Connector] Called fetchSavedShippingAddresses stub')
+    return Promise.resolve()
+}

--- a/web/app/integration-manager/_stub-connector/checkout/commands.js
+++ b/web/app/integration-manager/_stub-connector/checkout/commands.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+
 export const initCheckoutShippingPage = (url) => (dispatch) => {
     console.log('[Stub Connector] Called initCheckoutShippingPage stub')
     return Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/commands.js
+++ b/web/app/integration-manager/_stub-connector/commands.js
@@ -1,0 +1,21 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
+import * as accountCommands from './account/commands'
+import * as appCommands from './app/commands'
+import * as cartCommands from './cart/commands'
+import * as categoriesCommands from './categories/commands'
+import * as checkoutCommands from './checkout/commands'
+import * as homeCommands from './home/commands'
+import * as productsCommands from './products/commands'
+
+export default {
+    account: accountCommands,
+    app: appCommands,
+    cart: cartCommands,
+    categories: categoriesCommands,
+    checkout: checkoutCommands,
+    home: homeCommands,
+    products: productsCommands,
+}

--- a/web/app/integration-manager/_stub-connector/commands.js
+++ b/web/app/integration-manager/_stub-connector/commands.js
@@ -2,6 +2,8 @@
 /* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 
+/* eslint-disable no-unused-vars */
+
 import * as accountCommands from './account/commands'
 import * as appCommands from './app/commands'
 import * as cartCommands from './cart/commands'

--- a/web/app/integration-manager/_stub-connector/commands.js
+++ b/web/app/integration-manager/_stub-connector/commands.js
@@ -10,6 +10,9 @@ import * as checkoutCommands from './checkout/commands'
 import * as homeCommands from './home/commands'
 import * as productsCommands from './products/commands'
 
+export const submitNewsletter = (formData) => Promise.resolve()
+export const getSearchSuggestions = (query) => (dispatch) => Promise.resolve()
+
 export default {
     account: accountCommands,
     app: appCommands,
@@ -18,4 +21,6 @@ export default {
     checkout: checkoutCommands,
     home: homeCommands,
     products: productsCommands,
+    submitNewsletter,
+    getSearchSuggestions
 }

--- a/web/app/integration-manager/_stub-connector/config.js
+++ b/web/app/integration-manager/_stub-connector/config.js
@@ -1,0 +1,10 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
+// configuration is not currently used by the stub connector
+let config = {} // eslint-disable-line
+
+export const registerConfig = (cfg) => {
+    config = cfg
+}

--- a/web/app/integration-manager/_stub-connector/home/commands.js
+++ b/web/app/integration-manager/_stub-connector/home/commands.js
@@ -1,3 +1,7 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
 /* eslint-disable no-unused-vars */
 
 import {receiveHomeData} from '../../results'

--- a/web/app/integration-manager/_stub-connector/home/commands.js
+++ b/web/app/integration-manager/_stub-connector/home/commands.js
@@ -1,0 +1,1 @@
+export const initHomePage = (url) => (dispatch) => Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/home/commands.js
+++ b/web/app/integration-manager/_stub-connector/home/commands.js
@@ -14,10 +14,7 @@ export const initHomePage = (url) => (dispatch) => {
         }]
     }
 
-    return new Promise((resolve) => {
-        setTimeout(() => {
-            dispatch(receiveHomeData(exampleData))
-            resolve()
-        })
-    })
+    // We need to receive the carousel data async for it to work correctly
+    return Promise.resolve()
+        .then(() => dispatch(receiveHomeData(exampleData)))
 }

--- a/web/app/integration-manager/_stub-connector/home/commands.js
+++ b/web/app/integration-manager/_stub-connector/home/commands.js
@@ -1,6 +1,8 @@
 import {receiveHomeData} from '../../results'
 
 export const initHomePage = (url) => (dispatch) => {
+    console.log('[Stub Connector] Called initHomePage stub')
+    
     const exampleData = {
         banners: [{
             src: '//via.placeholder.com/400x200',

--- a/web/app/integration-manager/_stub-connector/home/commands.js
+++ b/web/app/integration-manager/_stub-connector/home/commands.js
@@ -1,8 +1,10 @@
+/* eslint-disable no-unused-vars */
+
 import {receiveHomeData} from '../../results'
 
 export const initHomePage = (url) => (dispatch) => {
     console.log('[Stub Connector] Called initHomePage stub')
-    
+
     const exampleData = {
         banners: [{
             src: '//via.placeholder.com/400x200',

--- a/web/app/integration-manager/_stub-connector/home/commands.js
+++ b/web/app/integration-manager/_stub-connector/home/commands.js
@@ -1,1 +1,23 @@
-export const initHomePage = (url) => (dispatch) => Promise.resolve()
+import {receiveHomeData} from '../../results'
+
+export const initHomePage = (url) => (dispatch) => {
+    const exampleData = {
+        banners: [{
+            src: '//via.placeholder.com/400x200',
+            alt: 'Placeholder Image'
+        }, {
+            src: '//via.placeholder.com/400x200',
+            alt: 'Placeholder Image'
+        }, {
+            src: '//via.placeholder.com/400x200',
+            alt: 'Placeholder Image'
+        }]
+    }
+
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            dispatch(receiveHomeData(exampleData))
+            resolve()
+        })
+    })
+}

--- a/web/app/integration-manager/_stub-connector/index.js
+++ b/web/app/integration-manager/_stub-connector/index.js
@@ -1,0 +1,12 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
+import commands from './commands'
+import reducer from './reducer'
+import {registerConfig} from './config'
+
+export const Connector = (cfg) => {
+    registerConfig(cfg)
+    return {commands, reducer}
+}

--- a/web/app/integration-manager/_stub-connector/products/commands.js
+++ b/web/app/integration-manager/_stub-connector/products/commands.js
@@ -1,13 +1,13 @@
 import {receiveProductDetailsProductData, receiveProductDetailsUIData} from '../../products/results'
 import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
+import {receiveFormInfo} from '../actions'
 
 export const initProductDetailsPage = (url) => (dispatch) => {
     const pathKey = urlToPathKey(url)
 
     const image = {
         src: '//via.placeholder.com/350x350',
-        alt: 'Product 1',
-        isMain: true
+        alt: 'Product 1'
     }
 
     const exampleData = {
@@ -23,9 +23,33 @@ export const initProductDetailsPage = (url) => (dispatch) => {
         }
     }
 
+    const exampleUIData = {
+        [pathKey]: {
+            breadcrumbs: [{
+                href: '/',
+                text: 'Home'
+            }, {
+                href: window.location.href,
+                text: 'Product 1'
+            }],
+            itemQuantity: 1
+        }
+    }
+
+    const exampleFormData = {
+        [pathKey]: {
+            submitUrl: 'submit',
+            method: 'POST',
+            uenc: '',
+            hiddenInputs: {}
+        }
+    }
+
     return new Promise((resolve) => {
         // For more information on the shape of the expected data, see ../../products/types
         dispatch(receiveProductDetailsProductData(exampleData))
+        dispatch(receiveProductDetailsUIData(exampleUIData))
+        dispatch(receiveFormInfo(exampleFormData))
         resolve()
     })
 }

--- a/web/app/integration-manager/_stub-connector/products/commands.js
+++ b/web/app/integration-manager/_stub-connector/products/commands.js
@@ -3,6 +3,8 @@ import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 import {receiveFormInfo} from '../actions'
 
 export const initProductDetailsPage = (url) => (dispatch) => {
+    console.log('[Stub Connector] Called initProductDetailsPage stub')
+    
     const pathKey = urlToPathKey(url)
 
     const image = {
@@ -52,4 +54,7 @@ export const initProductDetailsPage = (url) => (dispatch) => {
     return Promise.resolve()
 }
 
-export const getProductVariantData = (variationSelections, variants, categoryIds) => (dispatch) => Promise.resolve()
+export const getProductVariantData = (variationSelections, variants, categoryIds) => (dispatch) => {
+    console.log('[Stub Connector] Called getProductVariantData stub')
+    return Promise.resolve()
+}

--- a/web/app/integration-manager/_stub-connector/products/commands.js
+++ b/web/app/integration-manager/_stub-connector/products/commands.js
@@ -1,10 +1,12 @@
+/* eslint-disable no-unused-vars */
+
 import {receiveProductDetailsProductData, receiveProductDetailsUIData} from '../../products/results'
 import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 import {receiveFormInfo} from '../actions'
 
 export const initProductDetailsPage = (url) => (dispatch) => {
     console.log('[Stub Connector] Called initProductDetailsPage stub')
-    
+
     const pathKey = urlToPathKey(url)
 
     const image = {

--- a/web/app/integration-manager/_stub-connector/products/commands.js
+++ b/web/app/integration-manager/_stub-connector/products/commands.js
@@ -1,3 +1,7 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
 /* eslint-disable no-unused-vars */
 
 import {receiveProductDetailsProductData, receiveProductDetailsUIData} from '../../products/results'

--- a/web/app/integration-manager/_stub-connector/products/commands.js
+++ b/web/app/integration-manager/_stub-connector/products/commands.js
@@ -45,13 +45,11 @@ export const initProductDetailsPage = (url) => (dispatch) => {
         }
     }
 
-    return new Promise((resolve) => {
-        // For more information on the shape of the expected data, see ../../products/types
-        dispatch(receiveProductDetailsProductData(exampleData))
-        dispatch(receiveProductDetailsUIData(exampleUIData))
-        dispatch(receiveFormInfo(exampleFormData))
-        resolve()
-    })
+    // For more information on the shape of the expected data, see ../../products/types
+    dispatch(receiveProductDetailsProductData(exampleData))
+    dispatch(receiveProductDetailsUIData(exampleUIData))
+    dispatch(receiveFormInfo(exampleFormData))
+    return Promise.resolve()
 }
 
 export const getProductVariantData = (variationSelections, variants, categoryIds) => (dispatch) => Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/products/commands.js
+++ b/web/app/integration-manager/_stub-connector/products/commands.js
@@ -1,0 +1,3 @@
+export const initProductDetailsPage = (url) => (dispatch) => Promise.resolve()
+
+export const getProductVariantData = (variationSelections, variants, categoryIds) => (dispatch) => Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/products/commands.js
+++ b/web/app/integration-manager/_stub-connector/products/commands.js
@@ -1,3 +1,33 @@
-export const initProductDetailsPage = (url) => (dispatch) => Promise.resolve()
+import {receiveProductDetailsProductData, receiveProductDetailsUIData} from '../../products/results'
+import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
+
+export const initProductDetailsPage = (url) => (dispatch) => {
+    const pathKey = urlToPathKey(url)
+
+    const image = {
+        src: '//via.placeholder.com/350x350',
+        alt: 'Product 1',
+        isMain: true
+    }
+
+    const exampleData = {
+        [pathKey]: {
+            price: '$10.00',
+            available: true,
+            href: window.location.href,
+            thumbnail: image,
+            title: 'Product 1',
+            images: [image, image],
+            id: '1',
+            description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+        }
+    }
+
+    return new Promise((resolve) => {
+        // For more information on the shape of the expected data, see ../../products/types
+        dispatch(receiveProductDetailsProductData(exampleData))
+        resolve()
+    })
+}
 
 export const getProductVariantData = (variationSelections, variants, categoryIds) => (dispatch) => Promise.resolve()

--- a/web/app/integration-manager/_stub-connector/reducer.js
+++ b/web/app/integration-manager/_stub-connector/reducer.js
@@ -1,0 +1,20 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
+import {handleActions} from 'redux-actions'
+import {mergePayload} from '../../utils/reducer-utils'
+import {exampleAction} from './actions'
+
+import Immutable from 'immutable'
+
+const initialState = Immutable.Map()
+
+// Add project-specific actions here
+const reducer = handleActions({
+    // At least one action needs to be present for the reducer to combine correctly
+    // Replace this example action once you have a project specific action
+    [exampleAction]: mergePayload
+}, initialState)
+
+export default reducer

--- a/web/app/integration-manager/_stub-connector/reducer.js
+++ b/web/app/integration-manager/_stub-connector/reducer.js
@@ -4,7 +4,7 @@
 
 import {handleActions} from 'redux-actions'
 import {mergePayload} from '../../utils/reducer-utils'
-import {exampleAction} from './actions'
+import {exampleAction, receiveFormInfo} from './actions'
 
 import Immutable from 'immutable'
 
@@ -14,7 +14,8 @@ const initialState = Immutable.Map()
 const reducer = handleActions({
     // At least one action needs to be present for the reducer to combine correctly
     // Replace this example action once you have a project specific action
-    [exampleAction]: mergePayload
+    [exampleAction]: mergePayload,
+    [receiveFormInfo]: mergePayload
 }, initialState)
 
 export default reducer

--- a/web/app/integration-manager/_stub-connector/selectors.js
+++ b/web/app/integration-manager/_stub-connector/selectors.js
@@ -2,4 +2,12 @@
 /* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 
+import {createGetSelector} from 'reselect-immutable-helpers'
+
 export const getIntegrationManager = ({integrationManager}) => integrationManager
+
+// You'll sometimes get forms from the backend that require certain data in order to be submitted
+// Rather than exposing that data to the front end,
+// that data can be kept inside the integrationManager branch in the Redux Store
+// This selector can be used to access that data
+export const getFormInfoByKey = (formKey) => createGetSelector(getIntegrationManager, formKey)

--- a/web/app/integration-manager/_stub-connector/selectors.js
+++ b/web/app/integration-manager/_stub-connector/selectors.js
@@ -1,0 +1,21 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
+import Immutable from 'immutable'
+import {createSelector} from 'reselect'
+import {createGetSelector} from 'reselect-immutable-helpers'
+
+import {getIsLoggedIn} from '../../store/user/selectors'
+
+export const getIntegrationManager = ({integrationManager}) => integrationManager
+// export const getCustomerEntityID = createGetSelector(getIntegrationManager, 'customerEntityID', '')
+// export const getFormKey = createGetSelector(getIntegrationManager, 'formKey')
+// export const getIMProductDetailsByPathKey = (pathKey) => createGetSelector(getIntegrationManager, pathKey, Immutable.Map())
+// export const getUenc = (pathKey) => createGetSelector(getIMProductDetailsByPathKey(pathKey), 'uenc')
+
+// export const getCartBaseUrl = createSelector(
+//     getIsLoggedIn,
+//     getCustomerEntityID,
+//     (isLoggedIn, entityID) => `/rest/default/V1/${isLoggedIn ? 'carts/mine' : `guest-carts/${entityID}`}`
+// )

--- a/web/app/integration-manager/_stub-connector/selectors.js
+++ b/web/app/integration-manager/_stub-connector/selectors.js
@@ -2,20 +2,4 @@
 /* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 
-import Immutable from 'immutable'
-import {createSelector} from 'reselect'
-import {createGetSelector} from 'reselect-immutable-helpers'
-
-import {getIsLoggedIn} from '../../store/user/selectors'
-
 export const getIntegrationManager = ({integrationManager}) => integrationManager
-// export const getCustomerEntityID = createGetSelector(getIntegrationManager, 'customerEntityID', '')
-// export const getFormKey = createGetSelector(getIntegrationManager, 'formKey')
-// export const getIMProductDetailsByPathKey = (pathKey) => createGetSelector(getIntegrationManager, pathKey, Immutable.Map())
-// export const getUenc = (pathKey) => createGetSelector(getIMProductDetailsByPathKey(pathKey), 'uenc')
-
-// export const getCartBaseUrl = createSelector(
-//     getIsLoggedIn,
-//     getCustomerEntityID,
-//     (isLoggedIn, entityID) => `/rest/default/V1/${isLoggedIn ? 'carts/mine' : `guest-carts/${entityID}`}`
-// )

--- a/web/app/main.jsx
+++ b/web/app/main.jsx
@@ -26,7 +26,7 @@ import Stylesheet from './stylesheet.scss' // eslint-disable-line no-unused-vars
 
 
 // DO NOT USE! Merlins Connector is an example connector that is for demo only
-import {Connector} from './integration-manager/_merlins-connector'
+import {Connector} from './integration-manager/_stub-connector'
 // import {Connector} from './integration-manager/_sfcc-connector'
 import connectorExtension from './connector-extension'
 

--- a/web/app/main.jsx
+++ b/web/app/main.jsx
@@ -26,7 +26,7 @@ import Stylesheet from './stylesheet.scss' // eslint-disable-line no-unused-vars
 
 
 // DO NOT USE! Merlins Connector is an example connector that is for demo only
-import {Connector} from './integration-manager/_stub-connector'
+import {Connector} from './integration-manager/_merlins-connector'
 // import {Connector} from './integration-manager/_sfcc-connector'
 import connectorExtension from './connector-extension'
 


### PR DESCRIPTION
This PR adds an extremely basic connector which just stubs out all of the expected commands. This is to give partners who need to create a brand new custom connector a place to start from.

## Changes
- Create stub connector
- Create stubs for all commands the integration manager expects
- Include some utility commands inside the app commands to make things like page fetching, offline mode easier

## How to test-drive this PR
- In main.jsx, register the stub connector 
```
import {Connector} from './integration-manager/_stub-connector'
```
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
