### PR TITLE
Fix worker loading

### DIFF
--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -1,4 +1,4 @@
-/* global NATIVE_WEBPACK_ASTRO_VERSION, MESSAGING_SITE_ID, MESSAGING_ENABLED */
+/* global NATIVE_WEBPACK_ASTRO_VERSION, MESSAGING_SITE_ID, MESSAGING_ENABLED, DEBUG */
 import {getAssetUrl, getBuildOrigin, loadAsset, initCacheManifest} from 'progressive-web-sdk/dist/asset-utils'
 import {isSamsungBrowser, isFirefoxBrowser} from 'progressive-web-sdk/dist/utils/utils'
 import {displayPreloader} from 'progressive-web-sdk/dist/preloader'
@@ -153,7 +153,7 @@ const attemptToInitializeApp = () => {
             // supported and loaded, and messaging is enabled, so we can add a
             // deferred function to load and initialize the Messaging client.
             deferredUntilLoadComplete.push(
-                () => loadAndInitMessagingClient(IS_PREVIEW, MESSAGING_SITE_ID)
+                () => loadAndInitMessagingClient(DEBUG, MESSAGING_SITE_ID)
             )
         }
     }

--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -1,5 +1,5 @@
 /* global NATIVE_WEBPACK_ASTRO_VERSION, MESSAGING_SITE_ID, MESSAGING_ENABLED */
-import {getAssetUrl, loadAsset, initCacheManifest} from 'progressive-web-sdk/dist/asset-utils'
+import {getAssetUrl, getBuildOrigin, loadAsset, initCacheManifest} from 'progressive-web-sdk/dist/asset-utils'
 import {isSamsungBrowser, isFirefoxBrowser} from 'progressive-web-sdk/dist/utils/utils'
 import {displayPreloader} from 'progressive-web-sdk/dist/preloader'
 import cacheHashManifest from '../tmp/loader-cache-hash-manifest.json'
@@ -32,8 +32,12 @@ const attemptToInitializeApp = () => {
         return
     }
 
-    // This isn't accurate but does describe the case where the PR currently works
-    const IS_PREVIEW = /mobify-path=true/.test(document.cookie)
+    // Changing this to anything to do with Mobify Preview (i.e. Preview cookie,
+    // `preview` string in the URL) will incorrectly cause the worker loader to
+    // load the worker from a local development server
+    // See web/service-worker-loader.js
+    const IS_PREVIEW = getBuildOrigin().indexOf('cdn.mobify.com') === -1
+
     const ASTRO_VERSION = NATIVE_WEBPACK_ASTRO_VERSION // replaced at build time
     const messagingEnabled = MESSAGING_ENABLED  // replaced at build time
 

--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -32,18 +32,20 @@ const attemptToInitializeApp = () => {
         return
     }
 
-    // Changing this to anything to do with Mobify Preview (i.e. Preview cookie,
-    // `preview` string in the URL) will incorrectly cause the worker loader to
-    // load the worker from a local development server
-    // See web/service-worker-loader.js
-    const IS_PREVIEW = getBuildOrigin().indexOf('cdn.mobify.com') === -1
-
     const ASTRO_VERSION = NATIVE_WEBPACK_ASTRO_VERSION // replaced at build time
     const messagingEnabled = MESSAGING_ENABLED  // replaced at build time
 
     const CAPTURING_CDN = '//cdn.mobify.com/capturejs/capture-latest.min.js'
     const ASTRO_CLIENT_CDN = `//assets.mobify.com/astro/astro-client-${ASTRO_VERSION}.min.js`
-    const SW_LOADER_PATH = `/service-worker-loader.js?preview=${IS_PREVIEW}&b=${cacheHashManifest.buildDate}`
+
+    /**
+     * This needs to be based on whether this is a CDN environment, rather than
+     * a preview environment. `web/service-worker-loader.js` will use this value
+     * to determine whether it should load from a local development server, or
+     * from the CDN.
+     */
+    const IS_LOCAL_PREVIEW = getBuildOrigin().indexOf('cdn.mobify.com') === -1
+    const SW_LOADER_PATH = `/service-worker-loader.js?preview=${IS_LOCAL_PREVIEW}&b=${cacheHashManifest.buildDate}`
 
     window.Progressive = {
         AstroPromise: Promise.resolve({}),

--- a/web/webpack/base.main.js
+++ b/web/webpack/base.main.js
@@ -41,6 +41,7 @@ const config = {
             'lodash.keysin': path.resolve(process.cwd(), 'node_modules', 'lodash', 'keysIn'),
             'lodash.mapvalues': path.resolve(process.cwd(), 'node_modules', 'lodash', 'mapValues'),
             'lodash.throttle': path.resolve(process.cwd(), 'node_modules', 'lodash', 'throttle'),
+            react: path.resolve(process.cwd(), 'node_modules', 'react')
         }
     },
     plugins: [

--- a/web/webpack/dev.js
+++ b/web/webpack/dev.js
@@ -31,6 +31,12 @@ mainConfig.plugins = mainConfig.plugins.concat([
     })
 ])
 
+loaderConfig.plugins = loaderConfig.plugins.concat([
+    new webpack.DefinePlugin({
+        DEBUG: true
+    })
+])
+
 workerConfig.plugins = workerConfig.plugins.concat([
     new webpack.DefinePlugin({
         DEBUG: true

--- a/web/webpack/production.js
+++ b/web/webpack/production.js
@@ -34,6 +34,12 @@ baseMainConfig.module.rules = baseMainConfig.module.rules.concat({
     ]
 })
 
+baseLoaderConfig.plugins = baseLoaderConfig.plugins.concat([
+    new webpack.DefinePlugin({
+        DEBUG: false
+    })
+])
+
 workerConfig.plugins = workerConfig.plugins.concat([
     new webpack.DefinePlugin({
         DEBUG: false


### PR DESCRIPTION
Previewing a bundle from the CDN will attempt to load the main worker module from `https://localhost:8443/worker.js` - which will not work.

## Changes
- Instead of `IS_PREVIEW` boolean testing for a `mobify-path=true` cookie, look at the build origin of the `loader.js` script and evaluate to `false` if `cdn.mobify.com` is found
- Change `IS_PREVIEW` name to `IS_LOCAL_PREVIEW` to be a little more descriptive
- Add to Webpack config. to add DefinePlugin `DEBUG` value to loader file (both dev and production configs)
- Use `DEBUG` value from Webpack build process to pass to Messaging Client init instead, which is more accurate
- Also add a `resolve` handler for `react` so that `npm link progressive-web-sdk` can be used without error

## How to test-drive this PR
### CDN
- Run `npm run upload`
- Preview the preview URL it returns for the bundle that was created
- Ensure that the main worker is loaded from the CDN and not from `localhost`
### Local
- Run `npm run dev`
- Preview: https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=0
- Ensure the main worker is loaded from your local development server