### PR TITLE
[WEBDATA-120] Fix password confirmation

### DIFF
--- a/web/app/containers/checkout-confirmation/actions.js
+++ b/web/app/containers/checkout-confirmation/actions.js
@@ -5,6 +5,7 @@
 import {CHECKOUT_CONFIRMATION_MODAL, CHECKOUT_CONFIRMATION_REGISTRATION_FAILED} from './constants'
 import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
 import {createPropsSelector} from 'reselect-immutable-helpers'
+import {SubmissionError} from 'redux-form'
 import {addNotification, removeAllNotifications} from 'progressive-web-sdk/dist/store/notifications/actions'
 import {openModal} from 'progressive-web-sdk/dist/store/modals/actions'
 import * as shippingSelectors from '../../store/checkout/shipping/selectors'
@@ -40,7 +41,15 @@ export const submitRegisterForm = () => {
             billingAddressData
         } = registrationFormSelector(getState())
 
-        return dispatch(registerUser(firstname, lastname, email, password, password_confirmation))
+        /* eslint-disable camelcase */
+        if (password !== password_confirmation) {
+            return Promise.reject(new SubmissionError({
+                password_confirmation: 'Passwords are not the same'
+            }))
+        }
+        /* eslint-enable camelcase */
+
+        return dispatch(registerUser(firstname, lastname, email, password))
             .then(() => {
                 dispatch(openModal(CHECKOUT_CONFIRMATION_MODAL))
                 return dispatch(updateShippingAddress(shippingData))

--- a/web/app/containers/checkout-confirmation/actions.test.js
+++ b/web/app/containers/checkout-confirmation/actions.test.js
@@ -29,7 +29,8 @@ describe('submitRegisterForm', () => {
         form: {
             [CONFIRMATION_FORM_NAME]: {
                 values: {
-                    password: 'Test'
+                    password: 'Test',
+                    password_confirmation: 'Test'
                 }
             }
         }

--- a/web/app/containers/login/actions.js
+++ b/web/app/containers/login/actions.js
@@ -120,10 +120,9 @@ export const submitRegisterForm = (formValues) => (dispatch) => {
         firstname,
         lastname,
         email,
-        password,
-        password_confirmation
+        password
     } = formValues
 
-    return dispatch(registerUser(firstname, lastname, email, password, password_confirmation))
+    return dispatch(registerUser(firstname, lastname, email, password))
         .then(handleLoginSuccess)
 }

--- a/web/app/integration-manager/_merlins-connector/account/commands.js
+++ b/web/app/integration-manager/_merlins-connector/account/commands.js
@@ -33,6 +33,9 @@ export const initRegisterPage = (url) => (dispatch) => {
 const submitForm = (href, formValues, formSelector) => {
     return makeFormEncodedRequest(href, formValues, {method: 'POST'})
         .then(jqueryResponse)
+        .catch((error) => {
+            throw new SubmissionError({_error: 'Failed to login due to network error.'})
+        })
         .then((res) => {
             const [$, $response] = res // eslint-disable-line no-unused-vars
             if (isFormResponseInvalid($response, formSelector)) {
@@ -42,12 +45,6 @@ const submitForm = (href, formValues, formSelector) => {
                 throw new SubmissionError(error)
             }
             return '/customer/account'
-        })
-        .catch((error) => {
-            if (error.name !== 'SubmissionError') {
-                throw new SubmissionError({_error: 'Failed to login due to network error.'})
-            }
-            throw error
         })
 }
 

--- a/web/app/integration-manager/_merlins-connector/account/commands.js
+++ b/web/app/integration-manager/_merlins-connector/account/commands.js
@@ -69,7 +69,7 @@ export const login = (username, password, rememberMe) => (dispatch, getState) =>
     return submitForm(LOGIN_POST_URL, formData, '.form-login')
 }
 
-export const registerUser = (firstname, lastname, email, password, confirmPassword, rememberMe) => (dispatch, getState) => {
+export const registerUser = (firstname, lastname, email, password, rememberMe) => (dispatch, getState) => {
     const currentState = getState()
     const formKey = getFormKey(currentState)
 
@@ -78,7 +78,7 @@ export const registerUser = (firstname, lastname, email, password, confirmPasswo
         lastname,
         email,
         password,
-        password_confirmation: confirmPassword,
+        password_confirmation: password,
         form_key: formKey
     }
     if (rememberMe) {


### PR DESCRIPTION
This PR fixes the bug preventing registration of new user accounts. It also reads the Magento messages cookie to get the correct error message for the register and login forms.

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-120
 **Linked PRs**: (links to corresponding PRs, optional)

## Changes
- No longer pass the password confirmation value into the command
- Duplicate the password in the Merlin's connector for registration
- Check that the passwords match in the confirmation page registration form
- Read the error message out of the `mage-messages` cookie rather than using a hard-coded value

## How to test-drive this PR
- Preview Merlin's
- Attempt to register with a new email address (e.g. `yourname+webdata120@mobify.com`) 
- See that it works
