### PR TITLE
Update labels for full name field

### DIFF
--- a/web/app/containers/checkout-payment/partials/billing-address-form.jsx
+++ b/web/app/containers/checkout-payment/partials/billing-address-form.jsx
@@ -99,7 +99,7 @@ class BillingAddressForm extends React.Component {
                     {(newShippingAddressIsEnabled || !hasShippingAddress) &&
                         <div className="u-padding-md u-padding-top-lg u-padding-bottom-lg u-border-light-top">
                             <FieldRow>
-                                <ReduxForm.Field component={Field} name="name" label="Full name">
+                                <ReduxForm.Field component={Field} name="name" label="First & Last name">
                                     <input type="text" noValidate />
                                 </ReduxForm.Field>
                             </FieldRow>

--- a/web/app/containers/checkout-shipping/partials/shipping-address-fields.jsx
+++ b/web/app/containers/checkout-shipping/partials/shipping-address-fields.jsx
@@ -49,7 +49,7 @@ const ShippingAddressFields = ({
                 <ReduxForm.Field
                     component={Field}
                     name="name"
-                    label="Full Name"
+                    label="First & Last Name"
                 >
                     <input type="text" noValidate />
                 </ReduxForm.Field>


### PR DESCRIPTION
This PR updates the full name label for the shipping and billing forms. Mitch asked me to do this as part of the work for WEBDAT-114 (#700) but I forgot to include it in that PR. 

 **JIRA**:  https://mobify.atlassian.net/browse/WEBDATA-114
 **Linked PRs**: n/a

## Changes
- Changed shipping form full name label to First & Last Name
- Changed billing form full name label to First & Last Name

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- add an item to the cart and proceed to the shipping page
- the full name field should now be labeled "first & last name"
- fill out the form and proceed to the billing page
- uncheck billing same as shipping
- the full name field should now be labeled "first & last name"
