### PR TITLE
[WEBDATA-112] Check for empty forminfo value in addToCart

### DIFF
--- a/web/app/integration-manager/_merlins-connector/actions.js
+++ b/web/app/integration-manager/_merlins-connector/actions.js
@@ -8,6 +8,6 @@ import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
 // Actions that are returned out of the connector and reduced
 // by the app should go into ./results.js
 
-export const receiveFormInfo = createAction('Receive Form Info')
+export const receiveFormInfo = createAction('Receive Form Info', ['formInfo'])
 export const receiveEntityID = createAction('Receive Customer Entity ID', ['customerEntityID'])
 export const receiveFormKey = createAction('Receive Form Key', ['formKey'])

--- a/web/app/integration-manager/_merlins-connector/cart/commands.js
+++ b/web/app/integration-manager/_merlins-connector/cart/commands.js
@@ -61,7 +61,7 @@ export const addToCart = (productId, quantity) => (dispatch, getState) => {
     const hiddenInputs = formInfo.get('hiddenInputs')
 
     if (hiddenInputs === undefined) {
-        Promise.reject('Add to cart failed, form info missing')
+        return Promise.reject('Add to cart failed, form info missing')
     }
 
     const formValues = {

--- a/web/app/integration-manager/_merlins-connector/cart/commands.js
+++ b/web/app/integration-manager/_merlins-connector/cart/commands.js
@@ -7,7 +7,7 @@ import {jqueryResponse} from 'progressive-web-sdk/dist/jquery-response'
 import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 import {removeNotification} from 'progressive-web-sdk/dist/store/notifications/actions'
 import {createPropsSelector} from 'reselect-immutable-helpers'
-import {getUenc, getCartBaseUrl} from '../selectors'
+import {getUenc, getCartBaseUrl, getFormInfoByPathKey} from '../selectors'
 import {receiveEntityID} from '../actions'
 import {getSelectedShippingMethod, getShippingAddress} from '../../../store/checkout/shipping/selectors'
 import {receiveCartContents, receiveCartTotals} from '../../cart/results'
@@ -55,10 +55,13 @@ export const getCart = () => (dispatch) => {
 
 export const addToCart = (productId, quantity) => (dispatch, getState) => {
     const product = getProductById(productId)(getState())
-    const formInfo = getState().integrationManager.get(urlToPathKey(product.get('href')))
 
-    if (formInfo === undefined) {
-        return Promise.reject('There was an error with the addToCart form info')
+    const formInfo = getFormInfoByPathKey(urlToPathKey(product.get('href')))(getState())
+
+    const hiddenInputs = formInfo.get('hiddenInputs')
+
+    if (hiddenInputs === undefined) {
+        Promise.reject('Add to cart failed, form info missing')
     }
 
     const formValues = {

--- a/web/app/integration-manager/_merlins-connector/cart/commands.js
+++ b/web/app/integration-manager/_merlins-connector/cart/commands.js
@@ -56,6 +56,11 @@ export const getCart = () => (dispatch) => {
 export const addToCart = (productId, quantity) => (dispatch, getState) => {
     const product = getProductById(productId)(getState())
     const formInfo = getState().integrationManager.get(urlToPathKey(product.get('href')))
+
+    if (formInfo === undefined) {
+        return Promise.reject('There was an error with the addToCart form info')
+    }
+
     const formValues = {
         ...formInfo.get('hiddenInputs').toJS(),
         qty: quantity

--- a/web/app/integration-manager/_merlins-connector/selectors.js
+++ b/web/app/integration-manager/_merlins-connector/selectors.js
@@ -11,8 +11,9 @@ import {getIsLoggedIn} from '../../store/user/selectors'
 export const getIntegrationManager = ({integrationManager}) => integrationManager
 export const getCustomerEntityID = createGetSelector(getIntegrationManager, 'customerEntityID', '')
 export const getFormKey = createGetSelector(getIntegrationManager, 'formKey')
-export const getIMProductDetailsByPathKey = (pathKey) => createGetSelector(getIntegrationManager, pathKey, Immutable.Map())
-export const getUenc = (pathKey) => createGetSelector(getIMProductDetailsByPathKey(pathKey), 'uenc')
+export const getFormInfo = createGetSelector(getIntegrationManager, 'formInfo', Immutable.Map())
+export const getFormInfoByPathKey = (pathKey) => createGetSelector(getFormInfo, pathKey, Immutable.Map())
+export const getUenc = (pathKey) => createGetSelector(getFormInfoByPathKey(pathKey), 'uenc')
 
 export const getCartBaseUrl = createSelector(
     getIsLoggedIn,


### PR DESCRIPTION
# Check for empty forminfo value in addToCart

`formInfo` would return `undefined` in some rare intermittent cases during checkout. When that occurred, the `Add to Cart` button would remain disabled.

This PR fixes the add-to-cart remaining disabled, thus unblocking checkout.

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-112

## Changes
- Add a check for the intermittent empty form info to unblock addToCart

## How to test-drive this PR
- Use merlins connector
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)

## Steps to reliably reproduce:
1. Browse to https://www.merlinspotions.com/books/dragon-breeding-for-pleasure-and-profit.html
2. Click Add to Cart (should work)
3. Browse to https://www.merlinspotions.com/potions/unicorn-blood.html
4. Add to cart
5. Go to checkout
6. Remove Unicorn Blood
7. Browse to https://www.merlinspotions.com/books/dragon-breeding-for-pleasure-and-profit.html
8. Add to cart

Ensure that it all works, without Add To Cart button staying permanently disabled
