### PR TITLE
Fix amp validation errors when using the Sheet component

### DIFF
--- a/amp/app/__mocks__/svgMock.js
+++ b/amp/app/__mocks__/svgMock.js
@@ -1,0 +1,1 @@
+module.exports = ''

--- a/amp/app/containers/app/container.jsx
+++ b/amp/app/containers/app/container.jsx
@@ -13,7 +13,7 @@ const App = ({
     const button = '<button on="tap:menu-sheet.toggle">Button</button>';
     return (
         <body
-            id="app"
+            id="root"
             className="t-app"
         >
 

--- a/amp/app/containers/app/container.jsx
+++ b/amp/app/containers/app/container.jsx
@@ -3,29 +3,54 @@ import Header from '../header/container'
 import Footer from '../footer/container'
 import DangerousHTML from '../../components/dangerous-html'
 import Icon from '../../components/icon'
+import Sheet from '../../components/sheet'
 
 import sprite from '../../static/svg/sprite-dist/sprite.svg'
 
 const App = ({
     children
-}) => (
-    <div
-        id="app"
-        className="t-app"
-    >
-        <DangerousHTML html={sprite}>
-            {(htmlObj) => <div hidden dangerouslySetInnerHTML={htmlObj} />}
-        </DangerousHTML>
+}) => {
+    const button = '<button on="tap:menu-sheet.toggle">Button</button>';
+    return (
+        <body
+            id="app"
+            className="t-app"
+        >
 
-        <Icon name="user" title="User" />
+            <Sheet id="menu-sheet" headerContent={<div>Header</div>} footerContent={<div>Footer</div>}>
+                <ul>
+                    <li><a href="#">Home</a></li>
+                    <li><a href="#">Sign in</a></li>
+                    <li><a href="#">Potions</a></li>
+                    <li><a href="#">Spellbooks</a></li>
+                    <li><a href="#">Ingredients</a></li>
+                    <li><a href="#">Supplies</a></li>
+                    <li><a href="#">Charms</a></li>
+                    <li><a href="#">New Arrivals</a></li>
+                    <DangerousHTML html={button}>
+                        {(htmlObj) => <div dangerouslySetInnerHTML={htmlObj}/>}
+                    </DangerousHTML>
+                </ul>
+            </Sheet>
 
-        <Header />
+            <DangerousHTML html={button}>
+                {(htmlObj) => <div dangerouslySetInnerHTML={htmlObj}/>}
+            </DangerousHTML>
 
-        {children}
+            <DangerousHTML html={sprite}>
+                {(htmlObj) => <div hidden dangerouslySetInnerHTML={htmlObj}/>}
+            </DangerousHTML>
 
-        <Footer />
-    </div>
-)
+            <Icon name="user" title="User"/>
+
+            <Header />
+
+            {children}
+
+            <Footer />
+        </body>
+    )
+}
 
 App.propTypes = {
     children: PropTypes.node

--- a/amp/app/containers/app/container.jsx
+++ b/amp/app/containers/app/container.jsx
@@ -10,7 +10,7 @@ import sprite from '../../static/svg/sprite-dist/sprite.svg'
 const App = ({
     children
 }) => {
-    const button = '<button on="tap:menu-sheet.toggle">Button</button>';
+    const button = '<button on="tap:menu-sheet.toggle">Button</button>'
     return (
         <body
             id="root"
@@ -19,29 +19,29 @@ const App = ({
 
             <Sheet id="menu-sheet" headerContent={<div>Header</div>} footerContent={<div>Footer</div>}>
                 <ul>
-                    <li><a href="#">Home</a></li>
-                    <li><a href="#">Sign in</a></li>
-                    <li><a href="#">Potions</a></li>
-                    <li><a href="#">Spellbooks</a></li>
-                    <li><a href="#">Ingredients</a></li>
-                    <li><a href="#">Supplies</a></li>
-                    <li><a href="#">Charms</a></li>
-                    <li><a href="#">New Arrivals</a></li>
+                    <li><a href="/todo/">Home</a></li>
+                    <li><a href="/todo/">Sign in</a></li>
+                    <li><a href="/todo/">Potions</a></li>
+                    <li><a href="/todo/">Spellbooks</a></li>
+                    <li><a href="/todo/">Ingredients</a></li>
+                    <li><a href="/todo/">Supplies</a></li>
+                    <li><a href="/todo/">Charms</a></li>
+                    <li><a href="/todo/">New Arrivals</a></li>
                     <DangerousHTML html={button}>
-                        {(htmlObj) => <div dangerouslySetInnerHTML={htmlObj}/>}
+                        {(htmlObj) => <div dangerouslySetInnerHTML={htmlObj} />}
                     </DangerousHTML>
                 </ul>
             </Sheet>
 
             <DangerousHTML html={button}>
-                {(htmlObj) => <div dangerouslySetInnerHTML={htmlObj}/>}
+                {(htmlObj) => <div dangerouslySetInnerHTML={htmlObj} />}
             </DangerousHTML>
 
             <DangerousHTML html={sprite}>
-                {(htmlObj) => <div hidden dangerouslySetInnerHTML={htmlObj}/>}
+                {(htmlObj) => <div hidden dangerouslySetInnerHTML={htmlObj} />}
             </DangerousHTML>
 
-            <Icon name="user" title="User"/>
+            <Icon name="user" title="User" />
 
             <Header />
 

--- a/amp/app/containers/home/container.jsx
+++ b/amp/app/containers/home/container.jsx
@@ -2,10 +2,8 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 
 // import components
-import Sheet from '../../components/sheet'
 import AmpImage from 'mobify-amp-sdk/dist/components/amp-image'
 import Link from '../../components/link'
-import DangerousHTML from '../../components/dangerous-html'
 
 // import container styles
 import containerStyles from './container.scss'
@@ -14,30 +12,9 @@ const containerClass = 't-home'
 
 const Home = ({
     links,
-    title,
-    buttontest
+    title
 }) => (
     <div className={containerClass}>
-        <Sheet id="menu-sheet" headerContent="Header" footerContent="Footer">
-            <ul>
-                <li><a href="#">Home</a></li>
-                <li><a href="#">Sign in</a></li>
-                <li><a href="#">Potions</a></li>
-                <li><a href="#">Spellbooks</a></li>
-                <li><a href="#">Ingredients</a></li>
-                <li><a href="#">Supplies</a></li>
-                <li><a href="#">Charms</a></li>
-                <li><a href="#">New Arrivals</a></li>
-                <DangerousHTML html={buttontest}>
-                    {(htmlObj) => <div dangerouslySetInnerHTML={htmlObj} />}
-                </DangerousHTML>
-            </ul>
-        </Sheet>
-
-        <DangerousHTML html={buttontest}>
-            {(htmlObj) => <div dangerouslySetInnerHTML={htmlObj} />}
-        </DangerousHTML>
-
         <AmpImage src="/static/mobify.png" width="252" height="64" layout="fixed" />
 
         <h1>{title}</h1>
@@ -47,7 +24,6 @@ const Home = ({
 )
 
 Home.propTypes = {
-    buttontest: PropTypes.string,
     /**
      * An array of links
      */
@@ -63,8 +39,7 @@ Home.templateName = 'home'
 const mapStateToProps = (state) => ({
     links: state.links,
     title: `Home! - ${state.title}` || '',
-    className: containerClass,
-    buttontest: '<button on="tap:menu-sheet.toggle">Button</button>'
+    className: containerClass
 })
 
 export default connect(

--- a/amp/app/main.js
+++ b/amp/app/main.js
@@ -61,6 +61,7 @@ const render = (req, res, store, component, css) => {
         <ampSDK.AmpContext declareDependency={scripts.add}>
             <Provider store={store}>
                 <App>
+                    <h1>foo</h1>
                     <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.gaAccount} />
                     {React.createElement(component, {}, null)}
                 </App>

--- a/amp/app/main.js
+++ b/amp/app/main.js
@@ -61,7 +61,6 @@ const render = (req, res, store, component, css) => {
         <ampSDK.AmpContext declareDependency={scripts.add}>
             <Provider store={store}>
                 <App>
-                    <h1>foo</h1>
                     <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.gaAccount} />
                     {React.createElement(component, {}, null)}
                 </App>

--- a/amp/app/main.test.js
+++ b/amp/app/main.test.js
@@ -13,7 +13,7 @@ describe('Renders valid AMP', () => {
     })
 
     const validateAmp = (html) => {
-        expect(validator.validateString(html).status).toEqual('PASS')
+        expect(validator.validateString(html).errors).toEqual([])
     }
 
     const handle = (req) => {

--- a/amp/app/templates/amp-page.js
+++ b/amp/app/templates/amp-page.js
@@ -22,11 +22,7 @@ const ampPage = ({title, canonicalURL, body, css, ampScriptIncludes}) => (
                 ${css}
             </style>
         </head>
-        <body>
-            <div id="root">
-                ${body}
-            </div>
-        </body>
+        ${body}
     </html>
     `
     /*eslint-enable */

--- a/amp/package.json
+++ b/amp/package.json
@@ -78,7 +78,8 @@
   },
   "jest": {
     "moduleNameMapper": {
-      "\\.(css|scss)$": "<rootDir>/app/__mocks__/styleMock.js"
+      "\\.(css|scss)$": "<rootDir>/app/__mocks__/styleMock.js",
+      "\\.svg$": "<rootDir>/app/__mocks__/svgMock.js"
     }
   }
 }


### PR DESCRIPTION
## Changes
```
    Fix AMP validation errors which are breaking tests.

    - The amp-sidebar must be a direct child of the body tag for it to
      be valid. Render the <body> in react to fix.
    - Provide a Jest mock to stub out webpack imports of SVG assets which
      are not needed during testing.
```
## How to test-drive this PR
- Run `npm run test` locally - not captured by CircleCI at the moment, I guess.
