### PR TITLE
Handle empty Product Listing Pages from SFCC

### DIFF
--- a/web/app/integration-manager/_sfcc-connector/categories/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/categories/commands.js
@@ -48,8 +48,13 @@ export const initProductListPage = (url) => (dispatch) => {
         .then(() => makeApiRequest(makeCategorySearchURL(categoryID), {method: 'GET'}))
         .then((response) => response.json())
         .then(({hits, total}) => {
-            const productListData = parseProductListData(hits)
-            const products = Object.keys(productListData)
+            let productListData = []
+            let products = []
+
+            if (total > 0) {
+                productListData = parseProductListData(hits)
+                products = Object.keys(productListData)
+            }
 
             dispatch(receiveProductListProductData(productListData))
             dispatch(receiveCategoryContents(urlToPathKey(url), {

--- a/web/app/integration-manager/_sfcc-connector/categories/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/categories/commands.js
@@ -48,13 +48,16 @@ export const initProductListPage = (url) => (dispatch) => {
         .then(() => makeApiRequest(makeCategorySearchURL(categoryID), {method: 'GET'}))
         .then((response) => response.json())
         .then(({hits, total}) => {
-            let productListData = []
-            let products = []
-
-            if (total > 0) {
-                productListData = parseProductListData(hits)
-                products = Object.keys(productListData)
+            if (total === 0) {
+                dispatch(receiveCategoryContents(urlToPathKey(url), {
+                    products: [],
+                    itemCount: total
+                }))
+                return
             }
+
+            const productListData = parseProductListData(hits)
+            const products = Object.keys(productListData)
 
             dispatch(receiveProductListProductData(productListData))
             dispatch(receiveCategoryContents(urlToPathKey(url), {


### PR DESCRIPTION
Currently the SFCC integration does not properly render an empty PLP when there are 0 products.

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-107

## Changes
- Add response checks for empty product returned

## How to test-drive this PR
- In `/web/app/main.jsx`, import SFCC connector and comment out merlins connector
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1) **Note: use SFCC preview link**
- Navigate to Gift Certificates page, which should show no results instead of skeleton that go on forever. 
