### PR TITLE
Fail gracefully on cart page when SFCC basket Expires

### DIFF
--- a/web/app/containers/app/actions.js
+++ b/web/app/containers/app/actions.js
@@ -5,6 +5,7 @@
 /* eslint-disable import/namespace */
 /* eslint-disable import/named */
 import {EVENT_ACTION, Page} from 'progressive-web-sdk/dist/analytics/data-objects/'
+import {browserHistory} from 'progressive-web-sdk/dist/routing'
 
 import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 import {getAssetUrl} from 'progressive-web-sdk/dist/asset-utils'
@@ -88,3 +89,15 @@ export const signOut = () => (dispatch) => (
         ))
     })
 )
+
+export const handleCartExpiry = () => (dispatch) => {
+    // show notification, nav to homepage
+    dispatch(addNotification(
+        'cartUpdateError',
+        'Your cart has expired.',
+        true
+    ))
+    browserHistory.push({
+        pathname: '/'
+    })
+}

--- a/web/app/containers/app/actions.js
+++ b/web/app/containers/app/actions.js
@@ -91,7 +91,7 @@ export const signOut = () => (dispatch) => (
 )
 
 export const handleCartExpiry = () => (dispatch) => {
-    // show notification, nav to homepage
+    // show notification, navigate to homepage
     dispatch(addNotification(
         'cartUpdateError',
         'Your cart has expired.',

--- a/web/app/containers/app/actions.js
+++ b/web/app/containers/app/actions.js
@@ -91,13 +91,13 @@ export const signOut = () => (dispatch) => (
 )
 
 export const handleCartExpiry = () => (dispatch) => {
-    // show notification, navigate to homepage
+    // navigate to homepage, show notification
+    browserHistory.push({
+        pathname: '/'
+    })
     dispatch(addNotification(
         'cartUpdateError',
         'Your cart has expired.',
         true
     ))
-    browserHistory.push({
-        pathname: '/'
-    })
 }

--- a/web/app/containers/cart/actions.js
+++ b/web/app/containers/cart/actions.js
@@ -19,6 +19,7 @@ import {
     putPromoCode,
     deletePromoCode
 } from '../../integration-manager/cart/commands'
+import {handleCartExpiry} from '../app/actions'
 import {getDiscountCode} from '../../store/cart/selectors'
 import {addNotification} from 'progressive-web-sdk/dist/store/notifications/actions'
 import {getIsLoggedIn} from '../../store/user/selectors'
@@ -41,15 +42,34 @@ export const submitEstimateShipping = () => (dispatch, getState) => {
     dispatch(setTaxRequestPending(true))
     dispatch(fetchShippingMethodsEstimate(address))
         .then(() => dispatch(fetchTaxEstimate(address, shippingMethod.id)))
-        .catch(() => dispatch(addNotification(
-            'taxError',
-            'Unable to calculate tax and/or shipping.',
-            true
-        )))
+        .catch((error) => {
+            const message = error.message
+
+            if (message.includes('expired')) {
+                return dispatch(handleCartExpiry())
+            }
+            return dispatch(addNotification(
+                'taxError',
+                'Unable to calculate tax and/or shipping.',
+                true
+            ))
+        })
         .then(() => {
             dispatch(closeModal(CART_ESTIMATE_SHIPPING_MODAL))
             dispatch(setTaxRequestPending(false))
         })
+}
+
+const cartUpdateError = (error) => (dispatch) => {
+    const message = error.message
+    if (message.includes('expired')) {
+        return dispatch(handleCartExpiry())
+    }
+    return dispatch(addNotification(
+        'cartUpdateError',
+        message,
+        true
+    ))
 }
 
 export const removeItem = (itemID) => (dispatch) => {
@@ -59,13 +79,7 @@ export const removeItem = (itemID) => (dispatch) => {
             // all active webviews to refresh if needed
             trigger('cart:updated')
         })
-        .catch((error) => {
-            dispatch(addNotification(
-                'cartUpdateError',
-                error.message,
-                true
-            ))
-        })
+        .catch((error) => dispatch(cartUpdateError(error)))
 }
 
 export const saveToWishlist = (productId, itemId, productURL) => (dispatch, getState) => {
@@ -102,13 +116,7 @@ export const openRemoveItemModal = (itemId) => {
 
 export const updateItem = (itemId, itemQuantity) => (dispatch) => {
     return dispatch(updateItemQuantity(itemId, itemQuantity))
-        .catch((error) => {
-            dispatch(addNotification(
-                'cartUpdateError',
-                error.message,
-                true
-            ))
-        })
+        .catch((error) => dispatch(cartUpdateError(error)))
 }
 
 export const submitPromoCode = ({promo}) => (dispatch) => {

--- a/web/app/integration-manager/_sfcc-connector/cart/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/cart/commands.js
@@ -17,12 +17,12 @@ const addToCartRequest = (productId, quantity, basketId) => {
     }]
     // Use makeApiRequest here instead of makeAPIJsonRequest so we can deal with errors ourselves
     return makeApiRequest(`/baskets/${basketId}/items`, {method: 'POST', body: JSON.stringify(requestBody)})
+        .then((response) => response.json())
 }
 
 export const addToCart = (productId, quantity) => (dispatch) => (
     createBasket()
         .then((basket) => addToCartRequest(productId, quantity, basket.basket_id))
-        .then((response) => response.json())
         .then((basket) => {
             if (basket.fault) {
                 if (basket.fault.type === 'InvalidCustomerException') {
@@ -32,9 +32,9 @@ export const addToCart = (productId, quantity) => (dispatch) => (
                 }
                 throw new Error(basket.fault.message)
             }
-
-            return dispatch(handleCartData(basket))
+            return basket
         })
+        .then((basket) => dispatch(handleCartData(basket)))
         .catch(() => { throw new Error('Unable to add item to cart') })
 )
 

--- a/web/app/integration-manager/_sfcc-connector/cart/utils.js
+++ b/web/app/integration-manager/_sfcc-connector/cart/utils.js
@@ -136,5 +136,8 @@ export const handleCartData = (basket) => (dispatch) => {
 export const createNewBasket = () => (dispatch) => {
     deleteBasketID()
     return requestCartData()
-        .then((basket) => dispatch(handleCartData(basket)))
+        .then((basket) => {
+            dispatch(handleCartData(basket))
+            return basket
+        })
 }

--- a/web/app/integration-manager/_sfcc-connector/cart/utils.js
+++ b/web/app/integration-manager/_sfcc-connector/cart/utils.js
@@ -141,3 +141,22 @@ export const createNewBasket = () => (dispatch) => {
             return basket
         })
 }
+
+export const isCartExpired = ({fault}) => {
+    if (fault) {
+        if (fault.type === 'InvalidCustomerException') {
+            return true
+        }
+        throw new Error(fault.message)
+    }
+    return false
+}
+
+export const checkAndHandleCartExpiry = (basket) => (dispatch) => {
+    if (isCartExpired(basket)) {
+        return dispatch(createNewBasket())
+            .then((basket) => dispatch(handleCartData(basket)))
+            .then(() => { throw new Error('Your cart has expired.') })
+    }
+    return basket
+}

--- a/web/app/integration-manager/_sfcc-connector/checkout/commands.js
+++ b/web/app/integration-manager/_sfcc-connector/checkout/commands.js
@@ -3,7 +3,7 @@
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 
 import {SubmissionError} from 'redux-form'
-import {createBasket, handleCartData, requestCartData, createNewBasket} from '../cart/utils'
+import {createBasket, handleCartData, requestCartData, createNewBasket, checkAndHandleCartExpiry} from '../cart/utils'
 import {makeApiRequest, makeApiJsonRequest, getAuthToken, getAuthTokenPayload} from '../utils'
 import {getOrderTotal} from '../../../store/cart/selectors'
 import {populateLocationsData, createOrderAddressObject} from './utils'
@@ -19,6 +19,7 @@ export const fetchShippingMethodsEstimate = (inputAddress = {}) => (dispatch, ge
     return createBasket()
         .then((basket) => makeApiRequest(`/baskets/${basket.basket_id}/shipments/me/shipping_methods`, {method: 'GET'}))
         .then((response) => response.json())
+        .then((basket) => dispatch(checkAndHandleCartExpiry(basket)))
         .then(({applicable_shipping_methods}) => {
             const shippingMethods = applicable_shipping_methods
                   .map(({name, description, price, id}) => ({

--- a/web/app/main.jsx
+++ b/web/app/main.jsx
@@ -38,7 +38,7 @@ registerConnector(Connector({
     siteID: '2017refresh',
     clientID: '5640cc6b-f5e9-466e-9134-9853e9f9db93'
 }))
-registerConnectorExtension(connectorExtension)
+// registerConnectorExtension(connectorExtension)
 
 initCacheManifest(cacheHashManifest)
 


### PR DESCRIPTION
This PR adds checks for cart expiry to the cart pages commands. *Note* this PR is just part of the work for WEBDATA-108, further work needs to be done to handle cart expiry on the checkout-shipping and checkout-payment pages. 


 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-108
 **Linked PRs**: n/a

## Changes
- created app action to show cart expiry message & navigate to homepage (this will be used on the checkout-shipping and checkout-payment pages too)
- created SFCC cart util to check if a basket has expired, if it has create a new one and throw an error
- added check for cart expiry to add to cart command & retry add to cart on new cart 
- added check for cart expiry to remove and update item cart commands 


## Todos
- [ ] (if applicable) analytics events instrumented to measure impact of change

## How to test-drive this PR
- switch to the SFCC connector
- Run `npm run dev`
- Preview the [SFCC Site](https://preview.mobify.com/?url=https%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- add a few items to the cart
- wait for a while until the cart expires
- try adding another item to your cart
- the initial request will fail and a new cart will be created with that one item in it (check for the failure, if your cart doesn't empty then it's possible your cart didn't expire and is still valid)
- add a few more items to the cart
- navigate to the cart page
- wait for a while until the cart expires
- try updating an item's quantity or removing an item
- if your cart is still valid it will work, if it's not you will be redirected to the homepage and a notification will say your cart has expired
