### PR TITLE
Chrome dependency

### DIFF
--- a/web/scripts/install-google-chrome-stable.sh
+++ b/web/scripts/install-google-chrome-stable.sh
@@ -4,4 +4,4 @@
 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 sudo apt-get update
-sudo apt-get --fix-upgrade --only-upgrade install google-chrome-stable
+sudo apt-get --fix-broken --only-upgrade install google-chrome-stable

--- a/web/scripts/install-google-chrome-stable.sh
+++ b/web/scripts/install-google-chrome-stable.sh
@@ -4,4 +4,4 @@
 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
 sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
 sudo apt-get update
-sudo apt-get --only-upgrade install google-chrome-stable
+sudo apt-get --fix-upgrade --only-upgrade install google-chrome-stable


### PR DESCRIPTION
A number of builds recently started failing mysteriously at the step to install the latest stable version of Chrome. See https://circleci.com/gh/mobify/lancome-progressive/5070?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

The solution was to add a `--fix-broken` flag to `apt-get` to resolve missing/broken dependencies, and to ensure the build ran on Ubuntu 14.04 (setting in CircleCI). While the mysterious failures were not observed on platform-scaffold, this PR adds the flag anyway, just in case. 

 **Linked PRs**: https://github.com/mobify/lancome-progressive/pull/977

## Changes
- Add `--fix-broken` flag when installing latest Chrome

## How to test-drive this PR
- Rebuild https://circleci.com/gh/mobify/platform-scaffold/tree/chrome-dependency
- Ensure there are no errors in the log in Artifacts > logs > installChrome.log
