### PR TITLE
Build AppVeyor only on master and develop

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,12 @@ cache:
   - web/node_modules
   - native/node_modules
 
+# Build only on these branches
+branches:
+  only:
+    - master
+    - develop
+
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js or io.js


### PR DESCRIPTION
Turns out that the `appveyor.yaml` file overrides the settings configured through the Web UI (we think?)

## Changes
- Windows builds only on `develop` and `master`