### PR TITLE
Build AppVeyor only on master and develop

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,12 @@ cache:
   - web/node_modules
   - native/node_modules
 
+# Build only on these branches
+branches:
+  only:
+    - master
+    - develop
+
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js or io.js


### PR DESCRIPTION
Okay, this time for real:

1. We found that AppVeyor seems? to ignore the settings configured through the web ui if you provide a `appveyor.yaml` file. So, we've moved how to ignore builds to this file.

2. We also need to disable AppVeyor's "Pull Request" webhoook as per https://github.com/appveyor/ci/issues/882

## Changes
- AppVeyor builds only on master/develop