### PR TITLE
Log requests on the AMP server

### DIFF
--- a/amp/app/main.js
+++ b/amp/app/main.js
@@ -16,6 +16,7 @@ import path from 'path'
 import Promise from 'bluebird'
 import fetch from 'node-fetch'
 import express from 'express'
+import morgan from 'morgan'
 import React from 'react'
 import ReactDOMServer from 'react-dom/server'
 import _jsdom from 'jsdom'
@@ -106,8 +107,12 @@ const homePage = (req, res, next) => {
         .catch(next)
 }
 
-const app = express()
+const onLambda = process.env.hasOwnProperty('AWS_LAMBDA_FUNCTION_NAME')
 
+const app = express()
+const logger = morgan(onLambda ? 'short' : 'dev')
+
+app.use(logger)
 app.get('/', homePage)
 app.get('/potions.html', productListPage)
 app.get('/books.html', productListPage)
@@ -121,12 +126,9 @@ app.get('*.html', productDetailsPage)
 app.use('/static', express.static(path.resolve('./app/static')))
 
 
-
-const onLambda = process.env.hasOwnProperty('AWS_LAMBDA_FUNCTION_NAME')
-
-
 if (!onLambda && require.main === module) {
-    app.listen(3000, () => console.log('Example app listening on port 3000!'))
+    const port = 3000
+    app.listen(port, () => console.log(`AMP server listening on port ${port}!`))
 }
 
 

--- a/amp/app/main.js
+++ b/amp/app/main.js
@@ -110,9 +110,11 @@ const homePage = (req, res, next) => {
 const onLambda = process.env.hasOwnProperty('AWS_LAMBDA_FUNCTION_NAME')
 
 const app = express()
-const logger = morgan(onLambda ? 'short' : 'dev')
 
-app.use(logger)
+if (process.env.NODE_ENV !== 'test') {
+    app.use(morgan(onLambda ? 'short' : 'dev'))
+}
+
 app.get('/', homePage)
 app.get('/potions.html', productListPage)
 app.get('/books.html', productListPage)

--- a/amp/package.json
+++ b/amp/package.json
@@ -5,7 +5,8 @@
     "aws-serverless-express": "3.0.0",
     "encoding": "0.1.12",
     "express": "4.14.0",
-    "jsdom": "9.12.0"
+    "jsdom": "9.12.0",
+    "morgan": "1.8.2"
   },
   "devDependencies": {
     "amphtml-validator": "^1.0.20",

--- a/amp/scripts/watch.js
+++ b/amp/scripts/watch.js
@@ -41,7 +41,5 @@ compiler.watch(watchConfig, (err, stats) => {
         serverProcess.kill();
     }
 
-    serverProcess = spawn('node', [path.resolve(__dirname, '..', 'build', 'main.js')]);
-    serverProcess.stdout.on('data', data => console.log(data.toString()));
-    serverProcess.stderr.on('data', data => console.error(data.toString()));
+    serverProcess = spawn('node', [path.resolve(__dirname, '..', 'build', 'main.js')], {stdio: 'inherit'});
 });


### PR DESCRIPTION
Enable request logging for easier debugging. Prompted by the observation that the AMP validator makes x5 duplicate requests for each resource.

## How to test-drive this PR
- Run `npm i`
- Run `npm run dev`
- App should run as normal and log requests in the terminal.
