### PR TITLE
Add <meta charset='utf-8'> tag

### DIFF
--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -201,6 +201,11 @@ const attemptToInitializeApp = () => {
         loadAsset('meta', {
             name: 'theme-color',
             content: '#4e439b'
+        })
+
+        loadAsset('meta', {
+            name: 'charset',
+            content: 'UTF-8'
         });
 
         // Attempt to load the worker.

--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -205,7 +205,7 @@ const attemptToInitializeApp = () => {
 
         loadAsset('meta', {
             name: 'charset',
-            content: 'UTF-8'
+            content: 'utf-8'
         });
 
         // Attempt to load the worker.


### PR DESCRIPTION
Feedback from Sapient/Debenhams via @cdegit was that our PWA's are missing a `<meta charset='utf-8'>` tag (which should be added to avoid XSS attacks).  More info on this page: https://developer.mozilla.org/en/docs/Web/HTML/Element/meta

![image](https://user-images.githubusercontent.com/77138/27103722-7f1abe4e-503e-11e7-890e-af7389682563.png)

 **JIRA**: N/A
 **Linked PRs**: N/A

## Changes
- As it says in the title.

## Todos
~~- [ ] (if applicable) analytics events instrumented to measure impact of change~~

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Open dev tools and view the *Elements* tab. Verify there is a `<meta>` tag that has the `charset` property set to `'utf-8'`.
