### PR TITLE
Add missing styles for PLP and PDP

### DIFF
--- a/amp/app/containers/app/_base.scss
+++ b/amp/app/containers/app/_base.scss
@@ -46,7 +46,14 @@
 @import '../../styles/themes/amp-components/field'; // TODO: dont move to SDK
 
 @import '../../components/field-row/base';
+@import '../../components/field-row/theme';
 @import '../../styles/themes/amp-components/field-row'; // TODO: dont move to SDK
+
+@import '../footer/footer';
+
+
+@import '../../components/sheet/base';
+@import '../../components/sheet/theme';
 
 // Navigation style
 // ---

--- a/amp/app/containers/home/container.scss
+++ b/amp/app/containers/home/container.scss
@@ -7,12 +7,6 @@
 
 @import '../../styles/global';
 
-// @TODO MOVE TO APP CONTAINER
-@import '../footer/footer';
-
-@import '../../components/field-row/theme';
-@import '../../styles/themes/amp-components/field-row'; // TODO: dont move to SDK
-
 // App Styles
 // ===
 //
@@ -37,8 +31,6 @@
 
 @import '../../components/amp-lightbox/base';
 @import '../../components/amp-lightbox/theme';
-@import '../../components/sheet/base';
-@import '../../components/sheet/theme';
 
 
 // AMP Components

--- a/amp/app/containers/product-details/container.scss
+++ b/amp/app/containers/product-details/container.scss
@@ -6,6 +6,14 @@
 @import '../../styles/global';
 
 
+// App Styles
+// ===
+//
+// @TODO: Add some information here
+
+@import '../app/base';
+
+
 // Components
 // ===
 //
@@ -17,6 +25,8 @@
 
 @import '../../components/amp-lightbox/base';
 @import '../../components/amp-lightbox/theme';
+@import '../../components/sheet/base';
+@import '../../components/sheet/theme';
 
 
 // AMP Components

--- a/amp/app/containers/product-details/container.scss
+++ b/amp/app/containers/product-details/container.scss
@@ -25,8 +25,6 @@
 
 @import '../../components/amp-lightbox/base';
 @import '../../components/amp-lightbox/theme';
-@import '../../components/sheet/base';
-@import '../../components/sheet/theme';
 
 
 // AMP Components

--- a/amp/app/containers/product-list/container.scss
+++ b/amp/app/containers/product-list/container.scss
@@ -6,6 +6,14 @@
 @import '../../styles/global';
 
 
+// App Styles
+// ===
+//
+// @TODO: Add some information here
+
+@import '../app/base';
+
+
 // Components
 // ===
 //
@@ -17,6 +25,8 @@
 
 @import '../../components/amp-lightbox/base';
 @import '../../components/amp-lightbox/theme';
+@import '../../components/sheet/base';
+@import '../../components/sheet/theme';
 
 
 // AMP Components

--- a/amp/app/containers/product-list/container.scss
+++ b/amp/app/containers/product-list/container.scss
@@ -25,8 +25,6 @@
 
 @import '../../components/amp-lightbox/base';
 @import '../../components/amp-lightbox/theme';
-@import '../../components/sheet/base';
-@import '../../components/sheet/theme';
 
 
 // AMP Components


### PR DESCRIPTION
Our Home template looks great, but the PLP and PDP have giant icons and the nav bar doesn't look right. This PR fixes that.

~~**JIRA**: (link to JIRA ticket)~~

## Changes
- Add missing style includes to the stylesheets of the PLP and PDP

## How to test-drive this PR
- Run `npm test`
- Run `npm run dev`
- Check http://localhost:3000, http://localhost:3000/potions.html, http://localhost:3000/eye-of-newt.html
