### PR TITLE
Add description to category schema

### DIFF
--- a/web/app/integration-manager/_merlins-connector/categories/commands.js
+++ b/web/app/integration-manager/_merlins-connector/categories/commands.js
@@ -28,7 +28,7 @@ export const initProductListPage = (url) => (dispatch) => {
                 filters: priceFilterParser($, $response),
                 title,
                 searchTerm: searchTermMatch ? searchTermMatch[0] : null,
-                description: getTextFrom($response, '#text')
+                description: getTextFrom($response, '#text, .category-description')
             }))
             dispatch(receiveCategoryContents(pathKey, categoryProductsParser($, $response)))
         })

--- a/web/app/integration-manager/_merlins-connector/categories/commands.js
+++ b/web/app/integration-manager/_merlins-connector/categories/commands.js
@@ -7,6 +7,7 @@ import {receiveCategoryContents, receiveCategoryInformation} from '../../categor
 import {receiveProductListProductData} from '../../products/results'
 import categoryProductsParser, {parseCategoryTitle, parseCategoryId, priceFilterParser} from './parser'
 import {productListParser} from '../products/parsers'
+import {getTextFrom} from '../../../utils/parser-utils'
 import {fetchPageData} from '../app/commands'
 
 export const initProductListPage = (url) => (dispatch) => {
@@ -26,7 +27,8 @@ export const initProductListPage = (url) => (dispatch) => {
                 parentId: null,
                 filters: priceFilterParser($, $response),
                 title,
-                searchTerm: searchTermMatch ? searchTermMatch[0] : null
+                searchTerm: searchTermMatch ? searchTermMatch[0] : null,
+                description: getTextFrom($response, '#text')
             }))
             dispatch(receiveCategoryContents(pathKey, categoryProductsParser($, $response)))
         })

--- a/web/app/integration-manager/categories/types.js
+++ b/web/app/integration-manager/categories/types.js
@@ -15,7 +15,8 @@ export const CategoryInfo = Runtypes.Record({
     // Top-level categories have parentId = null
     parentId: Nullable(CategoryID),
 }).And(Runtypes.Optional({
-    icon: Runtypes.Union(IconID, Image)
+    icon: Runtypes.Union(IconID, Image),
+    description: Text
 }))
 
 export const CategoryContents = Runtypes.Record({

--- a/web/app/store/categories/selectors.js
+++ b/web/app/store/categories/selectors.js
@@ -23,6 +23,7 @@ export const getCategoryTitle = createGetSelector(getSelectedCategory, 'title')
 export const getCategoryParentID = createGetSelector(getSelectedCategory, 'parentId', null)
 export const getCategorySearchTerm = createGetSelector(getSelectedCategory, 'searchTerm')
 export const getCategoryCustomContent = createGetSelector(getSelectedCategory, 'custom')
+export const getCategoryDescription = createGetSelector(getSelectedCategory, 'description')
 
 export const getCategoryParent = createSelector(
     getCategories,


### PR DESCRIPTION
This PR adds the description key to the category schema to support the tutorial.

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-100
 **Linked PRs**: https://github.com/mobify/progressive-web-sdk/pull/680

## Changes
- Added description key to category types in IM
- Added description to PLP parsing in Merlins Connector
- Added description selector to category selectors


## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Follow the steps in part 2 of the tutorial (see PR linked above, not the tutorial that's currently live)
- Expand the description section on the resulting starters kit page
- You should see text there that matches the description text found on the desktop page. 
