### PR TITLE
AMP-61: ProductItem and ProductTile Components

### DIFF
--- a/amp/app/components/product-item/README.md
+++ b/amp/app/components/product-item/README.md
@@ -1,0 +1,11 @@
+```js
+import ProductItem from 'mobify-amp-sdk/dist/components/product-item'
+
+// SCSS import
+@import 'node_modules/mobify-amp-sdk/dist/components/product-item/base';
+```
+
+
+## Example Usage
+
+    <ProductItem text="Hear me roar!" />

--- a/amp/app/components/product-item/_base.scss
+++ b/amp/app/components/product-item/_base.scss
@@ -1,0 +1,19 @@
+// ProductItem
+// ===
+
+// ProductItem root
+// ---
+
+.amp-product-item {
+    // Root Class. Contains all core styles, typically for the component's
+    // wrapper element.
+}
+
+
+// Category
+// ---
+
+.amp-product-item__category {
+    font-size: $font-size - 2;
+    line-height: 1em;
+}

--- a/amp/app/components/product-item/index.jsx
+++ b/amp/app/components/product-item/index.jsx
@@ -12,8 +12,7 @@ const ProductItem = ({
     className,
     image,
     price,
-    title,
-    customWidth
+    title
 }) => {
     const classes = classNames('amp-product-item', 'u-flexbox', 'u-direction-row-reverse', className)
 
@@ -43,7 +42,7 @@ const ProductItem = ({
 
 
             {image &&
-                <div className="u-padding-end u-flex-none" style={{width: customWidth}}>
+                <div className="u-padding-end u-flex-none">
                     {image}
                 </div>
             }
@@ -74,12 +73,7 @@ ProductItem.propTypes = {
     className: PropTypes.string,
 
     /**
-     * Designates the custom width that accepets valid css units
-     */
-    customWidth: PropTypes.string,
-
-    /**
-     * Image of the product. Usually an `<img />` tag or `<Image />` component
+     * Image of the product. An `<AMPImage />` component.
      */
     image: PropTypes.node,
 

--- a/amp/app/components/product-item/index.jsx
+++ b/amp/app/components/product-item/index.jsx
@@ -1,0 +1,92 @@
+import React, {PropTypes} from 'react'
+import classNames from 'classnames'
+
+/**
+ * Product Item represents a single product and it's basic information: name,
+ * price, category and other desired information.
+ */
+
+const ProductItem = ({
+    category,
+    children,
+    className,
+    image,
+    price,
+    title,
+    customWidth
+}) => {
+    const classes = classNames('amp-product-item', 'u-flexbox', 'u-direction-row-reverse', className)
+
+    return (
+        <article className={classes}>
+            <div className="u-flex">
+                {!!category &&
+                    <p className="amp-product-item__category u-margin-bottom-sm u-color-brand">
+                        {category}
+                    </p>
+                }
+
+                <div className="u-margin-bottom-sm u-text-capitilize">
+                    {title}
+                </div>
+
+                {!!price &&
+                    <div>{price}</div>
+                }
+
+                {!!children &&
+                    <div>
+                        {children}
+                    </div>
+                }
+            </div>
+
+
+            {image &&
+                <div className="u-padding-end u-flex-none" style={{width: customWidth}}>
+                    {image}
+                </div>
+            }
+        </article>
+    )
+}
+
+
+ProductItem.propTypes = {
+    /**
+     * The ProductItem's name or designation
+     */
+    title: PropTypes.node.isRequired,
+
+    /**
+     * Designates the ProductItem's category (i.e. Potions, Books, etc.)
+     */
+    category: PropTypes.string,
+
+    /**
+     * Any children to be nested within this ProductItem
+     */
+    children: PropTypes.node,
+
+    /**
+     * Adds values to the `class` attribute of the root element
+     */
+    className: PropTypes.string,
+
+    /**
+     * Designates the custom width that accepets valid css units
+     */
+    customWidth: PropTypes.string,
+
+    /**
+     * Image of the product. Usually an `<img />` tag or `<Image />` component
+     */
+    image: PropTypes.node,
+
+    /**
+     * Designates the ProductItem's unit price
+     */
+    price: PropTypes.node
+}
+
+export default ProductItem

--- a/amp/app/components/product-item/test.js
+++ b/amp/app/components/product-item/test.js
@@ -1,0 +1,48 @@
+/* eslint-env jest */
+import {mount, shallow} from 'enzyme'
+import React from 'react'
+
+import ProductItem from './index.jsx'
+
+test('ProductItem renders without errors', () => {
+    const wrapper = mount(<ProductItem title="I am product!" />)
+    expect(wrapper.length).toBe(1)
+})
+
+/* eslint-disable newline-per-chained-call */
+test('includes the component class name with no className prop', () => {
+    const wrapper = shallow(<ProductItem title="I am product!" />)
+
+    expect(wrapper.hasClass('amp-product-item')).toBe(true)
+})
+
+test('does not render an \'undefined\' class with no className', () => {
+    const wrapper = shallow(<ProductItem title="I am product!" />)
+
+    expect(wrapper.hasClass('undefined')).toBe(false)
+})
+
+test('renders the contents of the className prop if present', () => {
+    [
+        'test',
+        'test another'
+    ].forEach((name) => {
+        const wrapper = shallow(<ProductItem title="I am product!" className={name} />)
+
+        expect(wrapper.hasClass(name)).toBe(true)
+    })
+})
+
+test('renders the category if it is passed in', () => {
+    const wrapper = shallow(<ProductItem title="Title" category="Category!" />)
+
+    const categoryTag = wrapper.find('.amp-product-item__category')
+    expect(categoryTag.length).toBe(1)
+    expect(categoryTag.text()).toBe('Category!')
+})
+
+test('renders the price if it is passed in', () => {
+    const wrapper = shallow(<ProductItem title="Title" price="$0.99" />)
+
+    expect(wrapper.find('div').someWhere((div) => div.text() === '$0.99')).toBe(true)
+})

--- a/amp/app/components/product-tile/README.md
+++ b/amp/app/components/product-tile/README.md
@@ -1,0 +1,12 @@
+```js
+// JS import
+import ProductItem from 'mobify-amp-sdk/dist/components/product-tile'
+
+// SCSS import
+@import 'node_modules/mobify-amp-sdk/dist/components/product-tile/base';
+```
+
+
+## Example Usage
+
+    <ProductTile text="Hear me roar!" />

--- a/amp/app/components/product-tile/_base.scss
+++ b/amp/app/components/product-tile/_base.scss
@@ -1,0 +1,17 @@
+// ProductTile
+// ===
+//
+// 1. 172px is the minimum predicated height of the tile based on how large the
+//    images are suppose to be at mobile viewport size. Avoids flash of moving content
+
+.amp-product-tile {
+    min-height: $unit * 21.5; // 1
+}
+
+
+// ProductTile Name
+// ---
+
+.amp-product-tile__name {
+    word-break: break-word;
+}

--- a/amp/app/components/product-tile/index.jsx
+++ b/amp/app/components/product-tile/index.jsx
@@ -1,0 +1,63 @@
+import React, {PropTypes} from 'react'
+import classNames from 'classnames'
+
+import AmpImage from 'mobify-amp-sdk/dist/components/amp-image'
+import ListTile from '../list-tile'
+import ProductItem from '../product-item'
+
+/**
+ * Product Tile represents a product and its basic information: image,
+ * link and price.
+ */
+
+const titleClassName = classNames(
+    'amp-product-tile__name',
+    'u-h4',
+    'u-text-family',
+    'u-text-weight-medium',
+    'u-color-neutral-60'
+)
+
+const ProductImage = ({src, alt}) => (
+    <AmpImage
+        src={src}
+        alt={alt}
+        layout="fixed"
+        height="150px"
+        width="120px"
+        />
+)
+
+ProductImage.propTypes = {
+    alt: PropTypes.string,
+    src: PropTypes.string
+}
+
+const ProductTile = ({className, thumbnail, href, price, title}) => {
+
+    return (
+        <ListTile className="amp-product-tile u-card" href={href}>
+            <ProductItem customWidth="45%"
+                className={classNames('u-align-center', className)}
+                title={<h2 className={titleClassName}>{title}</h2>}
+                price={<span className="u-text-weight-bold u-color-error">{price}</span>}
+                image={<ProductImage {...thumbnail} />} />
+        </ListTile>
+    )
+}
+
+ProductTile.propTypes = {
+    /**
+     * Optional className for the product tile
+     */
+    className: PropTypes.string,
+    href: PropTypes.string,
+    price: PropTypes.string,
+    thumbnail: PropTypes.shape({
+        alt: PropTypes.string.isRequired,
+        src: PropTypes.string.isRequired,
+    }),
+    title: PropTypes.string
+}
+
+export default ProductTile

--- a/amp/app/components/product-tile/test.js
+++ b/amp/app/components/product-tile/test.js
@@ -1,0 +1,34 @@
+import {mount, shallow} from 'enzyme'
+/* eslint-env jest */
+import React from 'react'
+
+import ProductTile from './index.jsx'
+import ProductItem from '../product-item/index.jsx'
+
+test('ProductTile renders without errors', () => {
+    const wrapper = mount(<ProductTile />)
+    expect(wrapper.length).toBe(1)
+})
+
+/* eslint-disable newline-per-chained-call */
+test('includes the component class name with no className prop', () => {
+    const wrapper = shallow(<ProductTile />)
+
+    expect(wrapper.hasClass('amp-product-tile')).toBe(true)
+})
+
+test('does not render an \'undefined\' class with no className', () => {
+    const wrapper = shallow(<ProductTile />)
+
+    expect(wrapper.hasClass('undefined')).toBe(false)
+})
+
+test('renders the contents of the className prop if present', () => {
+    [
+        'test',
+        'test another'
+    ].forEach((name) => {
+        const wrapper = shallow(<ProductTile className={name} />)
+        expect(wrapper.find(ProductItem).hasClass(name)).toBe(true)
+    })
+})


### PR DESCRIPTION
This PR adds components that are needed for the _PLP_ in **AMP-61**, it isn't the build-out of the _PLP_ itself.

**JIRA**: https://mobify.atlassian.net/browse/AMP-61

## Changes
- Added in `ProductItem` component, styles, test and README
- Added in `ProductTile` component, styles, test and README
  - Removed skeleton since we won't be needing it

## Todos
- [ ] Engi + 1

## How to test-drive this PR
- Run `npm run dev`
- Visit `localhost:3000`
- I added this code to a template to ensure that it worked, along with styles pulled in: `<ProductTile className="hi" href="/" price="$200" title="product" thumbnail={{alt: "test", src: "/static/mobify.png"}}/>`
