### PR TITLE
AMP: Font changes

### DIFF
--- a/amp/app/containers/app/container.jsx
+++ b/amp/app/containers/app/container.jsx
@@ -5,6 +5,7 @@ import Button from '../../components/button'
 import SkipLinks from '../../components/skip-links'
 import Navigation from '../navigation/container'
 import sprite from '../../static/svg/sprite-dist/sprite.svg'
+import * as ampSDK from '../../amp-sdk'
 
 const App = ({children}) => {
 

--- a/amp/app/containers/app/container.jsx
+++ b/amp/app/containers/app/container.jsx
@@ -5,7 +5,6 @@ import Button from '../../components/button'
 import SkipLinks from '../../components/skip-links'
 import Navigation from '../navigation/container'
 import sprite from '../../static/svg/sprite-dist/sprite.svg'
-import * as ampSDK from '../../amp-sdk'
 
 const App = ({children}) => {
 

--- a/amp/app/main.js
+++ b/amp/app/main.js
@@ -32,6 +32,7 @@ import * as ampSDK from './amp-sdk'
 
 import {initializeStore} from './data-integration/connectedStore'
 import {PAGE_TITLE} from './data-integration/constants'
+import {fontServe} from './templates/font-serve'
 
 
 const getFullUrl = (req) => {
@@ -57,7 +58,8 @@ const render = (req, res, store, component, css) => {
         canonicalURL: getFullUrl(req),
         body,
         css,
-        ampScriptIncludes: scripts.items().join('\n')
+        ampScriptIncludes: scripts.items().join('\n'),
+        fontServe: fontServe()
     })
     res.send(rendered)
 }

--- a/amp/app/templates/amp-page.js
+++ b/amp/app/templates/amp-page.js
@@ -2,7 +2,7 @@ const ampPage = ({title, canonicalURL, body, css, ampScriptIncludes}) => (
     /*eslint-disable */
     `
     <!doctype html>
-    <html amp lang="en" class="amp-border-box">
+    <html amp lang="en" class="wf-active">
         <head>
             <!-- Standard AMP markup -->
             <meta charset="utf-8">
@@ -10,6 +10,7 @@ const ampPage = ({title, canonicalURL, body, css, ampScriptIncludes}) => (
             <title>${title}</title>
             <link rel="canonical" href="${canonicalURL}" />
             <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1, user-scalable=no">
+            <link href="https://fonts.googleapis.com/css?family=Oswald:200,400" rel="stylesheet">
             <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 
             <!-- AMP Component JS includes go here -->

--- a/amp/app/templates/amp-page.js
+++ b/amp/app/templates/amp-page.js
@@ -9,10 +9,7 @@ const ampPage = ({title, canonicalURL, body, css, ampScriptIncludes, fontServe})
             <script async src="https://cdn.ampproject.org/v0.js"></script>
             <title>${title}</title>
             <link rel="canonical" href="${canonicalURL}" />
-
-            <!-- Font Serve: Insert <link rel="styleshet" href="/path/to/font-serve"> in <head> tag. It will only work with Typography.com, Fonts.com, Google Fonts, or Font Awesome. For more information, please read: https://www.ampproject.org/docs/guides/responsive/custom_fonts. If you want to use custom font then please use <AmpFont> component. @TODO add/fix component name when we add it. -->
             ${fontServe}
-
             <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1, user-scalable=no">
             <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 

--- a/amp/app/templates/amp-page.js
+++ b/amp/app/templates/amp-page.js
@@ -1,4 +1,4 @@
-const ampPage = ({title, canonicalURL, body, css, ampScriptIncludes}) => (
+const ampPage = ({title, canonicalURL, body, css, ampScriptIncludes, fontServe}) => (
     /*eslint-disable */
     `
     <!doctype html>
@@ -9,8 +9,11 @@ const ampPage = ({title, canonicalURL, body, css, ampScriptIncludes}) => (
             <script async src="https://cdn.ampproject.org/v0.js"></script>
             <title>${title}</title>
             <link rel="canonical" href="${canonicalURL}" />
+
+            <!-- Font Serve: Insert <link rel="styleshet" href="/path/to/font-serve"> in <head> tag. It will only work with Typography.com, Fonts.com, Google Fonts, or Font Awesome. For more information, please read: https://www.ampproject.org/docs/guides/responsive/custom_fonts. If you want to use custom font then please use <AmpFont> component. @TODO add/fix component name when we add it. -->
+            ${fontServe}
+
             <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1, user-scalable=no">
-            <link href="https://fonts.googleapis.com/css?family=Oswald:200,400" rel="stylesheet">
             <style amp-boilerplate>body{-webkit-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-moz-animation:-amp-start 8s steps(1,end) 0s 1 normal both;-ms-animation:-amp-start 8s steps(1,end) 0s 1 normal both;animation:-amp-start 8s steps(1,end) 0s 1 normal both}@-webkit-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-moz-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-ms-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@-o-keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}@keyframes -amp-start{from{visibility:hidden}to{visibility:visible}}</style><noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>
 
             <!-- AMP Component JS includes go here -->

--- a/amp/app/templates/font-serve.js
+++ b/amp/app/templates/font-serve.js
@@ -1,3 +1,15 @@
+// Font Serve
+// ---
+//
+// Font Serve: Insert <link rel="styleshet" href="/path/to/font-serve"> in
+// <head> tag. It will only work with Typography.com, Fonts.com, Google Fonts,
+// or Font Awesome. For more information, please read:
+// https://www.ampproject.org/docs/guides/responsive/custom_fonts. If you want
+// to use custom font then please use <AmpFont> component.
+
+// @TODO add/fix component name when we add it.
+
+
 export const fontServe = () => {
     return '<link href="https://fonts.googleapis.com/css?family=Oswald:200,400" rel="stylesheet">'
 }

--- a/amp/app/templates/font-serve.js
+++ b/amp/app/templates/font-serve.js
@@ -1,0 +1,3 @@
+export const fontServe = () => {
+    return '<link href="https://fonts.googleapis.com/css?family=Oswald:200,400" rel="stylesheet">'
+}


### PR DESCRIPTION
Font Changes

 **Linked PRs**: (links to corresponding PRs, optional)

## Changes
- Add Google fonts
- `wf-active` class same as PWA
- remove `amp-border-box` class, no longer need it

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](http://localhost:3000/)
- Check if Oswald font is working 
