### PR TITLE
Remove dependency code patching for integration manager usage

### DIFF
--- a/amp/app/data-integration/connectedStore.js
+++ b/amp/app/data-integration/connectedStore.js
@@ -15,11 +15,10 @@ import {CURRENT_URL} from '../../../web/app/containers/app/constants'
 
 import appReducer from './app-reducer'
 import footerReducer from '../../../web/app/containers/footer/reducer'
-import headerReducer from '../../../web/app/containers/header/reducer'
 import homeReducer from '../../../web/app/containers/home/reducer'
 import navigationReducer from '../../../web/app/containers/navigation/reducer'
-import productDetailsReducer from '../../../web/app/containers/product-details/reducer'
 import productListReducer from '../../../web/app/containers/product-list/reducer'
+import productDetailsReducer from './product-details-reducer'
 import categoryReducer from '../../../web/app/store/categories/reducer'
 import productReducer from '../../../web/app/store/products/reducer'
 
@@ -39,7 +38,6 @@ export const initializeStore = (fullUrl, container) => {
         const uiReducer = combineReducers({
             app: appReducer,
             footer: footerReducer,
-            header: headerReducer,
             home: homeReducer,
             navigation: navigationReducer,
             productDetails: productDetailsReducer,
@@ -50,7 +48,7 @@ export const initializeStore = (fullUrl, container) => {
             categories: categoryReducer,
             ui: uiReducer,
             products: productReducer,
-            integrationManager: imReducer,
+            integrationManager: imReducer
         })
 
         const middlewares = [

--- a/amp/app/data-integration/product-details-reducer.js
+++ b/amp/app/data-integration/product-details-reducer.js
@@ -1,0 +1,16 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
+import Immutable from 'immutable'
+import {handleActions} from 'redux-actions'
+
+import {receiveProductDetailsUIData} from '../../../web/app/integration-manager/products/results'
+
+import {mergePayload} from '../../../web/app/utils/reducer-utils'
+
+const reducer = handleActions({
+    [receiveProductDetailsUIData]: mergePayload,
+}, Immutable.Map())
+
+export default reducer

--- a/amp/webpack.config.js
+++ b/amp/webpack.config.js
@@ -28,13 +28,6 @@ module.exports = {
                 loader: 'babel-loader?cacheDirectory=true'
             },
             {
-                test: /\.js(x?)$/,
-                include: /progressive-web-sdk/,
-                use: [
-                    {loader: "imports-loader?window=>{location: {href: ''}}"}
-                ],
-            },
-            {
                 test: /\.scss$/,
                 use: [
                     {loader: 'css-loader?-autoprefixer&-url', options: {minimize : true}},


### PR DESCRIPTION
Make our own minimal reducers or simply stop using reducers that we don't need, in order to not end up importing code that relies on `window` and other web browser facilities to exist. 

~~**JIRA**: (link to JIRA ticket)~~

## Changes
- Add our own `product-details` reducer
- Stop importing the PWA's `header` reducer
- Remove code rewriting config from webpack config

## How to test-drive this PR
- Run `npm run dev`
- Check out http://localhost:3000, http://localhost:3000/eye-of-newt.html, http://localhost:3000/potions.html