### PR TITLE
Fix selector names referencing productPaths

### DIFF
--- a/web/app/store/categories/selectors.js
+++ b/web/app/store/categories/selectors.js
@@ -17,7 +17,7 @@ export const getSelectedCategory = createGetSelector(
 
 const PLACEHOLDER_URLS = Immutable.List(new Array(5).fill(PLACEHOLDER))
 
-export const getCategoryProductPaths = createGetSelector(getSelectedCategory, 'products', PLACEHOLDER_URLS)
+export const getCategoryProductIds = createGetSelector(getSelectedCategory, 'products', PLACEHOLDER_URLS)
 export const getCategoryItemCount = createGetSelector(getSelectedCategory, 'itemCount')
 export const getCategoryTitle = createGetSelector(getSelectedCategory, 'title')
 export const getCategoryParentID = createGetSelector(getSelectedCategory, 'parentId', null)
@@ -47,6 +47,6 @@ export const getCategoryParentHref = createGetSelector(
 
 export const getCategoryProducts = createSelector(
     getProducts,
-    getCategoryProductPaths,
-    (products, productUrls) => productUrls.map((path) => products.get(path))
+    getCategoryProductIds,
+    (products, productIds) => productIds.map((path) => products.get(path))
 )

--- a/web/app/store/categories/selectors.js
+++ b/web/app/store/categories/selectors.js
@@ -48,5 +48,5 @@ export const getCategoryParentHref = createGetSelector(
 export const getCategoryProducts = createSelector(
     getProducts,
     getCategoryProductIds,
-    (products, productIds) => productIds.map((path) => products.get(path))
+    (products, productIds) => productIds.map((id) => products.get(id))
 )


### PR DESCRIPTION
# Fix selector names referencing productPaths


## Changes
- Rename productPath selectors missed from this PR https://github.com/mobify/platform-scaffold/pull/711
