### PR TITLE
[HOTFIX] Tests on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ branches:
   only:
     - master
     - develop
+    - hotfix-tests-on-windows
 
 # Install scripts. (runs after repo cloning)
 install:
@@ -25,4 +26,4 @@ test_script:
 artifacts:
   - path: web\tests\screenshots
     name: Screenshots
- 
+

--- a/web/package.json
+++ b/web/package.json
@@ -136,7 +136,7 @@
     "test": "cross-env NODE_ENV=test jest",
     "test:all": "npm run lint && npm test -- --coverage",
     "test:build-size": "node tests/system/verify-build-size.js",
-    "test:e2e": "NODE_ENV=test node ./node_modules/nightwatch/bin/runner.js -c ./tests/system/nightwatch-config.js --suiteRetries 1",
+    "test:e2e": "cross-env NODE_ENV=test node ./node_modules/nightwatch/bin/runner.js -c ./tests/system/nightwatch-config.js --suiteRetries 1",
     "test:pwa-prod": "bash ./scripts/lighthouse-prod.sh",
     "test:pwa-ci": "bash ./scripts/lighthouse-ci.sh",
     "test:pwa-local": "bash ./scripts/lighthouse-local.sh",


### PR DESCRIPTION
AppVeyor tests on windows break. This PR will fix that.

 **JIRA**: N/A
 **Linked PRs**: N/A

## Changes
- add `cross-env` to `package.json` test command

## How to test-drive this PR
- Check that appveyor passes