### PR TITLE
Fix broken onboarding styles

### DIFF
--- a/web/app/containers/onboarding/_onboarding.scss
+++ b/web/app/containers/onboarding/_onboarding.scss
@@ -4,6 +4,8 @@
 // @TODO: Come back and clean up the below selectors when working on onboarding.
 
 .t-onboarding {
+    height: 100vh;
+
     .c-carousel,
     .carousel-item {
         height: 100%;

--- a/web/app/containers/onboarding/container.jsx
+++ b/web/app/containers/onboarding/container.jsx
@@ -52,9 +52,11 @@ OnboardingScreen.propTypes = {
 
 const Onboarding = ({carouselData}) => {
     return (
-        <Carousel allowLooping={false}>
-            {carouselData.map((val, idx) => <OnboardingScreen {...val} id={idx.toString()} key={idx.toString()} />)}
-        </Carousel>
+        <div className="t-onboarding">
+            <Carousel allowLooping={false}>
+                {carouselData.map((val, idx) => <OnboardingScreen {...val} id={idx.toString()} key={idx.toString()} />)}
+            </Carousel>
+        </div>
     )
 }
 

--- a/web/app/native/onboarding/onboarding.jsx
+++ b/web/app/native/onboarding/onboarding.jsx
@@ -80,11 +80,25 @@ if (MESSAGING_ENABLED) {
 
 const rootEl = document.getElementsByClassName('react-target')[0]
 
+// The app id is required in order for utility classes to work. All utility
+// classes have been defined by the following format:
+//
+//     #app u-utility-name {...}
+//
+// Notice the preceding id selector. This helps ensure utility classes have
+// higher specificity than most other class selectors, without relying on
+// !important declarations.
+const appId = 'app'
+
 // Login should always be the last stage, so do this last
 carouselData.push(login)
 
 // There's a bug in the Android webview that doesn't immediately register
 // the event handlers for the carousel, so we delay rendering to next runloop
 setTimeout(() => {
-    render(<Onboarding carouselData={carouselData} />, rootEl)
+    render(
+        <div id={appId}>
+            <Onboarding carouselData={carouselData} />
+        </div>
+    , rootEl)
 }, 0)


### PR DESCRIPTION
Onboarding styles (for Native) were broken. This change fixes them!

## Changes
- Add missing `app` id to onbaording wrapper to make utility classes work again
- Add missing `t-onboarding` class
- Add missing styles to ensure height of onboarding carousel is correct

## Todos
- ~~(if applicable) analytics events instrumented to measure impact of change~~

## How to test-drive this PR
- Make sure you are in the `/native` directory
- Run `run deps`
- Follow the `/native/readme.md` instructions to preview the app
- When the onboarding screen appears, **verify** that its styles are correct
