### PR TITLE
Pull out the Lighthouse reports directory into a var

### DIFF
--- a/web/tests/system/test-scripts/check-lighthouse-score.js
+++ b/web/tests/system/test-scripts/check-lighthouse-score.js
@@ -13,10 +13,11 @@ const chalk = require('chalk')
 
 let fileName
 let failure = false
+const reportsDir = 'tests/system/test-scripts/lighthouse/reports/'
 
-if (fs.existsSync('tests/system/test-scripts/lighthouse/reports/audit-local.report.html')) {
+if (fs.existsSync(`${reportsDir}audit-local.report.html`)) {
     fileName = 'audit-local'
-} else if (fs.existsSync('tests/system/test-scripts/lighthouse/reports/audit-prod.report.html')) {
+} else if (fs.existsSync(`${reportsDir}audit-prod.report.html`)) {
     fileName = 'audit-prod'
 } else {
     console.log('Error Lighthouse report not found.')
@@ -52,8 +53,8 @@ const checkTTI = function(jsonResults) {
     console.log(`${jsonResults.audits['total-byte-weight'].displayValue}`)
 }
 
-const jsonResults = JSON.parse(fs.readFileSync(`tests/system/test-scripts/lighthouse/reports/${fileName}.report.json`, 'utf8'))
-const htmlReport = fs.readFileSync(`tests/system/test-scripts/lighthouse/reports/${fileName}.report.html`, 'utf8')
+const jsonResults = JSON.parse(fs.readFileSync(`${reportsDir}${fileName}.report.json`, 'utf8'))
+const htmlReport = fs.readFileSync(`${reportsDir}${fileName}.report.html`, 'utf8')
 
 checkTTI(jsonResults)
 checkLighthouse(htmlReport)


### PR DESCRIPTION
## Changes
- Specify the path to the Lighthouse reports in one place

## How to test-drive this PR
- Rebuild on CI
- Verify that `check-lighthouse-score.js` can still find the Lighthouse reports