### PR TITLE
Footer updates

### DIFF
--- a/amp/app/containers/footer/container.jsx
+++ b/amp/app/containers/footer/container.jsx
@@ -1,14 +1,12 @@
 import React from 'react'
 
 // Partials
-import FooterNewsletterSubscription from './partials/footer-newsletter-subscription'
 import FooterNavigation from './partials/footer-navigation'
 import {ampComponent} from '../../amp-sdk'
 
 const Footer = () => {
     return (
         <footer className="t-footer">
-            <FooterNewsletterSubscription />
             <FooterNavigation />
         </footer>
     )

--- a/amp/app/containers/footer/partials/footer-navigation.jsx
+++ b/amp/app/containers/footer/partials/footer-navigation.jsx
@@ -3,6 +3,8 @@ import React from 'react'
 // Components
 import Link from '../../../components/link'
 
+import {canonicalURL} from '../../../utils'
+
 const footerLinks = [
     {text: 'Privacy and Cookie Policy', href: '/privacy-policy-cookie-restriction-mode/'},
     {text: 'Search Terms', href: '/search/term/popular/'},
@@ -15,7 +17,7 @@ const FooterNavigation = () => {
     return (
         <div className="t-footer__navigation u-padding-lg u-text-align-center">
             {footerLinks.map(({text, href}, index) => (
-                <Link className="t-footer__navigation-link" href={href} key={index}>
+                <Link className="t-footer__navigation-link" href={canonicalURL(href)} key={index}>
                     {text}
                 </Link>
             ))}


### PR DESCRIPTION
Make footer links go to the canonical site, remove email subscription (for now)

~~**JIRA**: (link to JIRA ticket)~~

## Changes
- Remove newsletter subscription until we fix our CORS headers for Merlins
- Make footer links go to the right places

## How to test-drive this PR
- Run `npm run dev`
- http://localhost:3000/potions.html - look at the footer and tap on the links