### PR TITLE
Remove tap highlighting to improve perceived performance in native apps

### DIFF
--- a/web/app/styles/base/_general.scss
+++ b/web/app/styles/base/_general.scss
@@ -18,6 +18,7 @@
 
     -moz-box-sizing: border-box;
     -webkit-box-sizing: border-box;
+    -webkit-tap-highlight-color: rgba(0,0,0,0);
 }
 
 html {


### PR DESCRIPTION
## Changes
- The current tap highlighting looks really bad in the Merlin's iOS app. Reason being - the tap highlight comes up but then immediately disappears, making the experience feel janky. This removes it in general, but I'd be up for hearing whether we want to keep it in the browser experience and limit this change only to the app.

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Try on device, notice no more tap highlighting when tapping on links.
