### PR TITLE
use passwordInput component in login and registration forms

### DIFF
--- a/web/app/containers/login/partials/common.jsx
+++ b/web/app/containers/login/partials/common.jsx
@@ -43,7 +43,7 @@ export const LoginField = ({label, type, forgotPassword, name, tooltip, analytic
             component={Field}
             >
             {isPassword ?
-                <PasswordInput isText buttonTextHide="Hide" buttonTextShow="Show" />
+                <PasswordInput isText buttonTextHide="Hide" buttonTextShow="Show" data-analytics-name={analyticsName} />
             :
                 <input type={type} data-analytics-name={analyticsName} />
             }

--- a/web/app/containers/login/partials/common.jsx
+++ b/web/app/containers/login/partials/common.jsx
@@ -9,6 +9,7 @@ import {openModal} from 'progressive-web-sdk/dist/store/modals/actions'
 
 import Field from 'progressive-web-sdk/dist/components/field'
 import FieldRow from 'progressive-web-sdk/dist/components/field-row'
+import PasswordInput from 'progressive-web-sdk/dist/components/password-input'
 import Link from 'progressive-web-sdk/dist/components/link'
 import {UI_NAME} from 'progressive-web-sdk/dist/analytics/data-objects/'
 
@@ -34,14 +35,18 @@ LoginFieldLabel.propTypes = {
     label: PropTypes.string
 }
 
-export const LoginField = ({label, type, forgotPassword, name, tooltip, analyticsName}) => (
+export const LoginField = ({label, type, forgotPassword, name, tooltip, analyticsName, isPassword}) => (
     <FieldRow>
         <ReduxFormField
             name={name}
             label={<LoginFieldLabel label={label} forgotPassword={forgotPassword} />}
             component={Field}
             >
-            <input type={type} data-analytics-name={analyticsName} />
+            {isPassword ?
+                <PasswordInput isText buttonTextHide="Hide" buttonTextShow="Show" />
+            :
+                <input type={type} data-analytics-name={analyticsName} />
+            }
         </ReduxFormField>
 
         {tooltip}
@@ -54,6 +59,7 @@ LoginField.propTypes = {
     name: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     forgotPassword: PropTypes.object,
+    isPassword: PropTypes.bool,
     tooltip: PropTypes.node
 }
 

--- a/web/app/containers/login/partials/register-form.jsx
+++ b/web/app/containers/login/partials/register-form.jsx
@@ -79,6 +79,7 @@ class RegisterForm extends React.Component {
                         name="password"
                         type="password"
                         analyticsName={UI_NAME.password}
+                        isPassword
                         />
 
                     <LoginField
@@ -86,6 +87,7 @@ class RegisterForm extends React.Component {
                         name="password_confirmation"
                         type="password"
                         analyticsName={UI_NAME.confirmPassword}
+                        isPassword
                         />
 
                     <LoginField

--- a/web/app/containers/login/partials/signin-form.jsx
+++ b/web/app/containers/login/partials/signin-form.jsx
@@ -60,6 +60,7 @@ class SignInForm extends React.Component {
                         type="password"
                         forgotPassword={{href: FORGOT_PASSWORD_PATH}}
                         analyticsName={UI_NAME.password}
+                        isPassword
                         />
 
                     <LoginField

--- a/web/app/styles/themes/_pw-components.scss
+++ b/web/app/styles/themes/_pw-components.scss
@@ -48,6 +48,7 @@
 @import 'node_modules/progressive-web-sdk/dist/components/nav-menu/base';
 @import 'node_modules/progressive-web-sdk/dist/components/nav-slider/base';
 // @import 'node_modules/progressive-web-sdk/dist/components/nested-navigation/base'; // has base styles, but isn't used
+@import 'node_modules/progressive-web-sdk/dist/components/password-input/base';
 @import 'node_modules/progressive-web-sdk/dist/components/progress-steps/base';
 // @import 'node_modules/progressive-web-sdk/dist/components/pagination/base'; // has base styles, but isn't used
 // @import 'node_modules/progressive-web-sdk/dist/components/rating/base'; // has base styles, but isn't used
@@ -96,6 +97,7 @@
 @import 'pw-components/nav-menu';
 @import 'pw-components/nav-slider';
 @import 'pw-components/progress-steps';
+@import 'pw-components/password-input';
 @import 'pw-components/search';
 @import 'pw-components/sheet';
 @import 'pw-components/skeleton-block';

--- a/web/app/styles/themes/pw-components/_password-input.scss
+++ b/web/app/styles/themes/pw-components/_password-input.scss
@@ -1,20 +1,20 @@
 // Password Input Theme
 // ===
 
-
 .pw-password-input {
     width: 100%;
 }
 
 
+// Password Input Toggle
+// ---
+//
+// 1. to override SDK base style
 .pw-password-input__toggle {
+    padding: 0 !important; // 1
+
+    color: $brand-color;
+    font-weight: $semi-bold-font-weight;
     font-size: $font-size;
-
-    .pw-button__inner {
-        padding: 0;
-
-        color: $brand-color;
-        font-weight: $semi-bold-font-weight;
-        text-transform: uppercase;
-    }
+    text-transform: uppercase;
 }

--- a/web/app/styles/themes/pw-components/_password-input.scss
+++ b/web/app/styles/themes/pw-components/_password-input.scss
@@ -1,0 +1,20 @@
+// Password Input Theme
+// ===
+
+
+.pw-password-input {
+    width: 100%;
+}
+
+
+.pw-password-input__toggle {
+    font-size: $font-size;
+
+    .pw-button__inner {
+        padding: 0;
+
+        color: $brand-color;
+        font-weight: $semi-bold-font-weight;
+        text-transform: uppercase;
+    }
+}


### PR DESCRIPTION
use passwordInput component in login and registration forms

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1419

## Changes
- use passwordInput in sign in and registration form


## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Go to login page and check sign in and register forms

##Note
- We need to merge and publish https://github.com/mobify/progressive-web-sdk/pull/716 first then merge this