### PR TITLE
AMP-46 - bundle upload command

### DIFF
--- a/amp/package.json
+++ b/amp/package.json
@@ -37,6 +37,7 @@
     "mobify-amp-sdk": "0.0.2",
     "mobify-code-style": "2.8.3",
     "ncp": "2.0.0",
+    "node-exceptions": "^2.0.2",
     "node-fetch": "1.6.3",
     "node-mocks-http": "^1.6.2",
     "node-sass": "4.5.2",
@@ -84,7 +85,7 @@
   },
   "jest": {
     "setupFiles": [
-        "<rootDir>/app/jest-setup.js"
+      "<rootDir>/app/jest-setup.js"
     ],
     "moduleNameMapper": {
       "\\.(css|scss)$": "<rootDir>/app/__mocks__/styleMock.js",

--- a/amp/package.json
+++ b/amp/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "amphtml-validator": "^1.0.20",
+    "archiver": "1.3.0",
     "autoprefixer": "6.7.7",
     "babel-cli": "6.24.1",
     "babel-loader": "6.4.1",

--- a/amp/scripts/build/build.js
+++ b/amp/scripts/build/build.js
@@ -13,6 +13,7 @@ const common = require('../common');
 const rimraf = Promise.promisify(require('rimraf'));
 const fs = Promise.promisifyAll(require('fs'));
 const ncp = Promise.promisify(require('ncp').ncp);
+const archiver = require('archiver');
 
 const here = path.resolve(path.join(__dirname))
 const ampRootDir = path.resolve(path.join(__dirname), '..', '..')
@@ -38,6 +39,7 @@ const main = () => {
         .then(() => {
             const commitId = git.long()
             const outputDir = path.join(buildDir, commitId)
+            const outputZip = outputDir + '.zip'
             const staticOutDir = path.join(outputDir, 'static')
             const serverOutDir = path.join(outputDir, 'server')
 
@@ -63,6 +65,21 @@ const main = () => {
                 .tap(() => info('Copying configs'))
                 .then(() => ncp(path.join(here, 'cloudformation.yaml'), path.join(outputDir, 'cloudformation.yaml')))
                 .then(() => ncp(path.join(here, 'cloudformation-static.yaml'), path.join(outputDir, 'cloudformation-static.yaml')))
+
+                .tap(() => info('Archiving'))
+                .then(() => new Promise(resolve => {
+                    const output = fs.createWriteStream(outputZip);
+                    const archive = archiver('zip', {zlib: { level: 9 }});
+
+                    output.on('close', resolve)
+
+                    archive.pipe(output)
+                    archive.directory(outputDir, commitId)
+                    archive.finalize()
+                }))
+
+                .tap(() => info('Cleaning up'))
+                .then(() => rimraf(outputDir))
 
                 .tap(() => success(`Built version '${commitId}' successfully`))
         })

--- a/amp/scripts/bundles.js
+++ b/amp/scripts/bundles.js
@@ -57,9 +57,9 @@ const list = ({projectSlug}) => {
 const upload = ({projectSlug, file}) => {
     const url = listCreateURL(projectSlug)
     step(`Uploading bundle "${file}" to "${url}"`)
-    // const parsed = path.parse(file)
-    // parsed.ext !== '.zip' && abort('Expected a zip file')
-    // parsed.name.length !== gitRevisionLength && abort(`Expected a ${gitRevisionLength}-character git revision`)
+    const parsed = path.parse(file)
+    parsed.ext !== '.zip' && abort('Expected a zip file')
+    parsed.name.length !== gitRevisionLength && abort(`Expected a ${gitRevisionLength}-character git revision`)
 
     const buildRequestBody = () => (
         fs.readFileAsync(file)

--- a/amp/scripts/bundles.js
+++ b/amp/scripts/bundles.js
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 const process = require('process')
 const yargs = require('yargs');
 const path = require('path');
@@ -83,7 +82,7 @@ const upload = ({projectSlug, file}) => {
 const main = () => {
     const argv = (
         yargs
-        .usage('Usage: $0 <command> [options]')
+        .usage('Manage AMP bundles deployed through Mobify Cloud\n\nUsage: $0 <command> [options]')
         .command('list <projectSlug>', 'List uploaded bundles')
         .command('upload <projectSlug> <file>', 'Upload a new bundle')
         .demandCommand()

--- a/amp/scripts/bundles.js
+++ b/amp/scripts/bundles.js
@@ -65,7 +65,7 @@ const upload = ({projectSlug, file}) => {
         fs.readFileAsync(file)
         .then(buffer => buffer.toString('base64'))
         .then(base64 => ({
-            message: 'message',
+            message: parsed.name,
             artifact: `data:application/zip;base64,${base64}`
         }))
     )

--- a/amp/scripts/bundles.js
+++ b/amp/scripts/bundles.js
@@ -10,7 +10,7 @@ const fs = Promise.promisifyAll(require('fs'))
 const ne = require('node-exceptions')
 const fetch = require('node-fetch')
 
-const {success, info, error, step} = common
+const {info, error, step} = common
 
 const gitRevisionLength = 40
 

--- a/amp/scripts/bundles.js
+++ b/amp/scripts/bundles.js
@@ -24,6 +24,7 @@ const win = process.platform === 'win32'
 const home = win ? process.env.USERPROFILE : process.env.HOME
 const configFile = path.join(home, '.mobify')
 
+const pprint = (obj) => JSON.stringify(obj, null, 4)
 
 const getCredentials = () => (
     fs.readFileAsync(configFile)
@@ -50,7 +51,7 @@ const list = ({projectSlug}) => {
             headers: headers(credentials)
         }))
         .then(res => res.json())
-        .then(data => info(JSON.stringify(data, null, 4)))
+        .then(data => info(pprint(data)))
 }
 
 const upload = ({projectSlug, file}) => {
@@ -76,7 +77,7 @@ const upload = ({projectSlug, file}) => {
             body: JSON.stringify(body)
         }))
         .then(res => res.json())
-        .then(data => info(JSON.stringify(data, null, 4)))
+        .then(data => info(pprint(data)))
 }
 
 const main = () => {

--- a/amp/scripts/bundles.js
+++ b/amp/scripts/bundles.js
@@ -8,6 +8,7 @@ const child_process = require('child_process')
 const Promise = require('Bluebird')
 const fs = Promise.promisifyAll(require('fs'))
 const ne = require('node-exceptions')
+const fetch = require('node-fetch')
 
 const {success, info, error, step} = common
 
@@ -20,16 +21,42 @@ class LogicalException extends ne.LogicalException {}
 
 const abort = (msg) => {throw new LogicalException(msg)}
 
+const win = process.platform === 'win32'
+const home = win ? process.env.USERPROFILE : process.env.HOME
+const configFile = path.join(home, '.mobify')
+
+
+const getCredentials = () => (
+    fs.readFileAsync(configFile)
+        .then(json => JSON.parse(json))
+        .then(d => ({username: d.username, api_key: d.api_key}))
+        .catch(e => abort(
+            `Credentials file "${configFile}" not found or invalid\n` +
+            'Visit https://cloud.mobify.com/account for steps on authorizing your computer to push bundles.'
+        ))
+)
+
+const headers = ({api_key}) => ({
+    'User-Agent': `amp-sdk`,
+    'Authorization': `Bearer ${api_key}`,
+    'Content-Type': 'application/json',
+    'Accept': 'application/json'
+})
 
 const list = ({projectSlug}) => {
-    const url = listCreateURL(projectSlug)
-    step(`Fetching bundles from "${url}"`)
-    const bundles = Array.apply(null, new Array(20)).map((_, i) => ({active: i===0, name: `Bundle ${i}`}))
-    success(bundles.map(bundle => `${bundle.name} ${bundle.active ? "(active)" : ""} `).join('\n'))
-}
+    // const url = listCreateURL(projectSlug)
+    // step(`Fetching bundles from "${url}"`)
 
-const activate = ({projectSlug, version}) => {
-    step(`Activating version "${version}"`)
+    // TODO: Just checking that we can make a basic request...
+    const url = 'https://cloud.mobify.com/api/v2/users/obrook@mobify.com/businesses/'
+
+    return getCredentials()
+        .then(credentials => fetch(url, {
+            method: 'GET',
+            headers: headers(credentials)
+        }))
+        .then(res => res.json())
+        .then(res => info(JSON.stringify(res, null, 4)))
 }
 
 const upload = ({projectSlug, file}) => {
@@ -39,37 +66,45 @@ const upload = ({projectSlug, file}) => {
     // parsed.ext !== '.zip' && abort('Expected a zip file')
     // parsed.name.length !== gitRevisionLength && abort(`Expected a ${gitRevisionLength}-character git revision`)
 
-    fs.readFileAsync(file)
+    const buildRequestBody = () => (
+        fs.readFileAsync(file)
         .then(buffer => buffer.toString('base64'))
-        .then(base64 => {
-            const payload = {
-                message: 'message',
-                artifact: base64,
-            }
-            info(JSON.stringify(payload, null, 4))
+        .then(base64 => ({message: 'message', artifact: base64}))
+    )
+
+    return Promise.all([getCredentials(), buildRequestBody()])
+        .then(([credentials, body]) => {
+            info(JSON.stringify(credentials, null, 4))
+            info('----')
+            info(JSON.stringify(body, null, 4))
         })
 }
 
 const main = () => {
-    try {
-        const argv = (
-            yargs
-            .usage('Usage: $0 <command> [options]')
-            .command('list', 'List uploaded bundles', {}, list)
-            .command('activate <version>', 'Activate an uploaded bundle', {}, activate)
-            .command('upload <file>', 'Upload a new bundle', {}, upload)
-            .demandCommand()
-            .help()
-            .argv
-        )
-    } catch (e) {
-        if (e instanceof LogicalException) {
-            error(e.message)
-            process.exitCode = 1
-        } else {
-            throw e
+    const argv = (
+        yargs
+        .usage('Usage: $0 <command> [options]')
+        .command('list', 'List uploaded bundles')
+        .command('upload <file>', 'Upload a new bundle')
+        .demandCommand()
+        .help()
+        .argv
+    )
+
+    const command = argv._[0]
+    const commands = {list, upload}
+
+    Promise.resolve()
+        .then(_ => commands[command](argv))
+        .catch(e => {
+            if (e instanceof LogicalException) {
+                error(e.message)
+                process.exitCode = 1
+            } else {
+                throw e
+            }
         }
-    }
+    )
 }
 
 

--- a/amp/scripts/bundles.js
+++ b/amp/scripts/bundles.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+const process = require('process')
+const yargs = require('yargs');
+const path = require('path');
+const common = require('./common');
+const child_process = require('child_process')
+const Promise = require('Bluebird')
+const fs = Promise.promisifyAll(require('fs'))
+const ne = require('node-exceptions')
+
+const {success, info, error, step} = common
+
+const gitRevisionLength = 40
+
+const mobifyCloudURL = `https://cloud.mobify.com`
+const listCreateURL = (projectSlug) => `${mobifyCloudURL}/api/v2/amp/projects/${projectSlug}/amp/bundles/`
+
+class LogicalException extends ne.LogicalException {}
+
+const abort = (msg) => {throw new LogicalException(msg)}
+
+
+const list = ({projectSlug}) => {
+    const url = listCreateURL(projectSlug)
+    step(`Fetching bundles from "${url}"`)
+    const bundles = Array.apply(null, new Array(20)).map((_, i) => ({active: i===0, name: `Bundle ${i}`}))
+    success(bundles.map(bundle => `${bundle.name} ${bundle.active ? "(active)" : ""} `).join('\n'))
+}
+
+const activate = ({projectSlug, version}) => {
+    step(`Activating version "${version}"`)
+}
+
+const upload = ({projectSlug, file}) => {
+    const url = listCreateURL(projectSlug)
+    step(`Uploading bundle "${file}" to "${url}"`)
+    // const parsed = path.parse(file)
+    // parsed.ext !== '.zip' && abort('Expected a zip file')
+    // parsed.name.length !== gitRevisionLength && abort(`Expected a ${gitRevisionLength}-character git revision`)
+
+    fs.readFileAsync(file)
+        .then(buffer => buffer.toString('base64'))
+        .then(base64 => {
+            const payload = {
+                message: 'message',
+                artifact: base64,
+            }
+            info(JSON.stringify(payload, null, 4))
+        })
+}
+
+const main = () => {
+    try {
+        const argv = (
+            yargs
+            .usage('Usage: $0 <command> [options]')
+            .command('list', 'List uploaded bundles', {}, list)
+            .command('activate <version>', 'Activate an uploaded bundle', {}, activate)
+            .command('upload <file>', 'Upload a new bundle', {}, upload)
+            .demandCommand()
+            .help()
+            .argv
+        )
+    } catch (e) {
+        if (e instanceof LogicalException) {
+            error(e.message)
+            process.exitCode = 1
+        } else {
+            throw e
+        }
+    }
+}
+
+
+if (require.main === module) {
+    main()
+}

--- a/amp/scripts/bundles.js
+++ b/amp/scripts/bundles.js
@@ -14,7 +14,7 @@ const {info, error, step} = common
 
 const gitRevisionLength = 40
 
-const mobifyCloudURL = `http://cloud-dev.mobify.com:8000`
+const mobifyCloudURL = process.env['MOBIFY_CLOUD_URL'] || 'https://cloud.mobify.com/'
 const listCreateURL = (projectSlug) => `${mobifyCloudURL}/api/v2/projects/${projectSlug}/amp/bundles/`
 
 class LogicalException extends ne.LogicalException {}

--- a/amp/scripts/bundles.js
+++ b/amp/scripts/bundles.js
@@ -26,15 +26,18 @@ const configFile = path.join(home, '.mobify')
 
 const pprint = (obj) => JSON.stringify(obj, null, 4)
 
-const getCredentials = () => (
-    fs.readFileAsync(configFile)
+const getCredentials = () => {
+    const override = process.env['MOBIFY_DEPLOYMENT_CREDENTIALS']
+    const json = override !== undefined ? Promise.resolve(override) : fs.readFileAsync(configFile)
+
+    return json
         .then(json => JSON.parse(json))
         .then(d => ({username: d.username, api_key: d.api_key}))
         .catch(e => abort(
             `Credentials file "${configFile}" not found or invalid\n` +
             'Visit https://cloud.mobify.com/account for steps on authorizing your computer to push bundles.'
         ))
-)
+}
 
 const headers = ({api_key}) => ({
     'User-Agent': `amp-sdk`,


### PR DESCRIPTION
 **JIRA**: https://mobify.atlassian.net/browse/AMP-46

## Changes
- Change build script to build zip files (which Cloud expects)
- Provide  a `bundles.js` script for management of bundles on cloud.
- Include basic upload and list commands for the endpoints we have.

## Note
The list command is a little bare at the moment - we need it to show which version is the active one, which we can only do once we have deployments actually going through Cloud.

## How to test-drive this PR
- Set up and run Cloud locally.
- Set your machine up with the superuser credentials for deployment:

```
➜  amp git:(amp-46--upload-command) cat ~/.mobify
{
  "username": "fixture+super.user@test.com",
  "api_key": "asdf"
}
```
- Run:
```
npm run build
./scripts/bundles.js upload project-41 build/[commit].zip
./scripts/bundles.js list project-41
```

You should see a list of uploaded bundles.