### PR TITLE
Fix Stretched Product Thumbnails

### DIFF
--- a/web/app/connectors/_merlins-connector/products/parsers.js
+++ b/web/app/connectors/_merlins-connector/products/parsers.js
@@ -47,8 +47,7 @@ export const productDetailsParser = ($, $html) => {
         price: getTextFrom($mainContent, '.product-info-price .price-wrapper .price'),
         description: getTextFrom($mainContent, '.product.info.detailed .product.attibute.description p'),
         available: getAvailabilityFrom($mainContent),
-        images,
-        thumbnail: images[0]
+        images
     }
 }
 


### PR DESCRIPTION
Certain images were getting stretched due to a mismatch in height/width ratios. The assets that we were using and the values that we were forcing upon them did not quite match.

## Changes
- Remove from our product parser where we override the product thumbnail with the images from the PDP carousels (they aren't the right dimensions for use in the thumbnails)

## Todos
- ~~(if applicable) analytics events instrumented to measure impact of change~~

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Visit a Product List page and note that height/width of the product thumbnails (they should look good)
- Click any of the products to visit its PDP and let it load, then hit the back button to return to the product list page
- **Verify** that the product thumbnails still look correct (don't stretch or deform)

## Result

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/734535/27566343-8e31c2aa-5a99-11e7-9751-f5625e08643f.png) | ![after](https://user-images.githubusercontent.com/734535/27566346-9396dfbe-5a99-11e7-8f02-eb357ab28ad6.png) |

