### PR TITLE
Fix SFCC modal import path

### DIFF
--- a/web/app/connectors/_sfcc-connector/app/commands.js
+++ b/web/app/connectors/_sfcc-connector/app/commands.js
@@ -15,7 +15,7 @@ import {parseCategories, parseSearchSuggestions} from '../parsers'
 import {browserHistory} from 'progressive-web-sdk/dist/routing'
 
 import {getSignInURL, getCheckoutShippingURL, getCartURL, buildSearchURL} from '../config'
-import {SIGNED_IN_NAV_ITEM_TYPE, GUEST_NAV_ITEM_TYPE} from '../../../containers/navigation/constants'
+import {SIGNED_IN_NAV_ITEM_TYPE, GUEST_NAV_ITEM_TYPE} from '../../../modals/navigation/constants'
 
 
 export const fetchNavigationData = () => (dispatch) => {


### PR DESCRIPTION
# Fix SFCC modal import path


## Changes

- Updates the import path for Modal constants, which was previoulsy not updated on SFCC connector


## How to test-drive this PR
- Use SFCC connector
- Run `npm run dev`
- Ensure webpack doesn't throw and compile-time errors
