### PR TITLE
Fix for building for lambda breakage

### DIFF
--- a/amp/package.json
+++ b/amp/package.json
@@ -23,6 +23,7 @@
     "classnames": "2.2.5",
     "copy": "0.3.0",
     "cross-env": "4.0.0",
+    "cross-env-test": "^0.1.1",
     "css-loader": "0.28.1",
     "enzyme": "2.8.2",
     "eslint": "3.19.0",
@@ -84,7 +85,7 @@
     "test:all": "npm run lint && npm test -- --coverage",
     "build": "cross-env NODE_ENV=production node ./scripts/build/build.js",
     "deploy": "node ./scripts/deploy.js",
-    "postinstall": "node ./scripts/postinstall.js"
+    "postinstall": "cross-env-test NODE_ENV=production || node ./scripts/postinstall.js"
   },
   "jest": {
     "setupFiles": [


### PR DESCRIPTION
Don’t run our `postinstall` logic when building for production, because it won’t work, and we don’t need it

~~**JIRA**: (link to JIRA ticket)~~
 **Linked PRs**: #801 

## Changes
- Conditionally run `postinstall` logic based on node env

## How to test-drive this PR
- `npm i`
- Make sure everything works as normal
- `npm run build`
- Make sure build is successful