### PR TITLE
Fix messaging client load and init promise

### DIFF
--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -8,6 +8,7 @@ import {
     getMessagingSWVersion,
     isLocalStorageAvailable,
     loadAndInitMessagingClient,
+    addMessagingClientInitPromise,
     loadScript,
     loadScriptAsPromise,
     prefetchLink,
@@ -256,6 +257,10 @@ const attemptToInitializeApp = () => {
             src: getAssetUrl('main.js')
         })
 
+        // This must come before vendor.js, or before the Webpack chunk that contains
+        // Messaging React components
+        addMessagingClientInitPromise(messagingEnabled)
+
         loadScriptAsPromise({
             id: 'progressive-web-vendor',
             src: getAssetUrl('vendor.js')
@@ -275,10 +280,6 @@ const attemptToInitializeApp = () => {
          ? loadWorker()
          : Promise.resolve(false)
         ).then((serviceWorkerSupported) => {
-
-            // Set up the Messaging client integration - this must be
-            // done now, but the work is deferred until after script
-            // loading is complete.
             setupMessagingClient(serviceWorkerSupported, messagingEnabled)
         })
 

--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -257,8 +257,13 @@ const attemptToInitializeApp = () => {
             src: getAssetUrl('main.js')
         })
 
-        // This must come before vendor.js, or before the Webpack chunk that contains
-        // Messaging React components
+        /**
+         * This must be called before vendor.js is loaded (or before the Webpack
+         * chunk that contains Messaging React components is loaded)
+         *
+         * This creates a Promise: `window.Progressive.MessagingClientInitPromise`
+         * which will be resolved or rejected later by the method `setupMessagingClient`
+         */
         createGlobalMessagingClientInitPromise(messagingEnabled)
 
         loadScriptAsPromise({

--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -8,7 +8,7 @@ import {
     getMessagingSWVersion,
     isLocalStorageAvailable,
     loadAndInitMessagingClient,
-    addMessagingClientInitPromise,
+    createGlobalMessagingClientInitPromise,
     loadScript,
     loadScriptAsPromise,
     prefetchLink,
@@ -259,7 +259,7 @@ const attemptToInitializeApp = () => {
 
         // This must come before vendor.js, or before the Webpack chunk that contains
         // Messaging React components
-        addMessagingClientInitPromise(messagingEnabled)
+        createGlobalMessagingClientInitPromise(messagingEnabled)
 
         loadScriptAsPromise({
             id: 'progressive-web-vendor',

--- a/web/app/utils/loader-utils.js
+++ b/web/app/utils/loader-utils.js
@@ -72,6 +72,21 @@ export const isLocalStorageAvailable = () => {
 
 const MESSAGING_PWA_CLIENT_PATH = 'https://webpush-cdn.mobify.net/pwa-messaging-client.js'
 
+// Creating an early promise that users of the Messaging Client can
+// chain from means they don't need to poll for its existence
+let clientInitResolver = () => {}
+let clientInitRejecter = () => {}
+export const addMessagingClientInitPromise = (messagingEnabled) => {
+    if (!messagingEnabled) {
+        return
+    }
+
+    window.Progressive.MessagingClientInitPromise = new Promise((resolve, reject) => {
+        clientInitResolver = resolve
+        clientInitRejecter = reject
+    })
+}
+
 /**
  * Start the asynchronous loading and intialization of the Messaging client,
  * storing a Promise in window.Progressive.MessagingClientInitPromise that
@@ -79,16 +94,7 @@ const MESSAGING_PWA_CLIENT_PATH = 'https://webpush-cdn.mobify.net/pwa-messaging-
  * or init fails, the Promise is rejected.
  */
 export const loadAndInitMessagingClient = (debug, siteId) => {
-    // Creating an early promise that users of the Messaging Client can
-    // chain means they don't need to poll for its existence
-    let clientInitResolver
-    let clientInitRejecter
-    window.Progressive.MessagingClientInitPromise = new Promise((resolve, reject) => {
-        clientInitResolver = resolve
-        clientInitRejecter = reject
-    })
-
-    return () => loadScriptAsPromise({
+    loadScriptAsPromise({
         id: 'progressive-web-messaging-client',
         src: MESSAGING_PWA_CLIENT_PATH,
         rejectOnError: true

--- a/web/app/utils/loader-utils.js
+++ b/web/app/utils/loader-utils.js
@@ -74,8 +74,9 @@ const MESSAGING_PWA_CLIENT_PATH = 'https://webpush-cdn.mobify.net/pwa-messaging-
 
 // Creating an early promise that users of the Messaging Client can
 // chain from means they don't need to poll for its existence
-let clientInitResolver = () => {}
-let clientInitRejecter = () => {}
+const logMessagingSetupError = () => console.error('`LoaderUtils.createGlobalMessagingClientInitPromise` must be called before `setupMessagingClient`')
+let clientInitResolver = logMessagingSetupError
+let clientInitRejecter = logMessagingSetupError
 export const createGlobalMessagingClientInitPromise = (messagingEnabled) => {
     if (!messagingEnabled) {
         return

--- a/web/app/utils/loader-utils.js
+++ b/web/app/utils/loader-utils.js
@@ -76,7 +76,7 @@ const MESSAGING_PWA_CLIENT_PATH = 'https://webpush-cdn.mobify.net/pwa-messaging-
 // chain from means they don't need to poll for its existence
 let clientInitResolver = () => {}
 let clientInitRejecter = () => {}
-export const addMessagingClientInitPromise = (messagingEnabled) => {
+export const createGlobalMessagingClientInitPromise = (messagingEnabled) => {
     if (!messagingEnabled) {
         return
     }

--- a/web/tests/system/page-objects/push-messaging.js
+++ b/web/tests/system/page-objects/push-messaging.js
@@ -47,6 +47,10 @@ PushMessaging.prototype.acceptDefaultAsk = function() {
 PushMessaging.prototype.assertSubscribed = function() {
     const self = this
     this.browser
+        // We have a pause here to allow Messaging Client to perform Service Worker
+        // operations that are asynchronous and take time - this may need to be
+        // increased
+        .pause(2000)
         .execute(() => {
             return window.Progressive.MessagingClient.LocalStorage.get('mobifyMessagingClientSubscriptionStatus')
         }, [], ({value}) => {

--- a/web/tests/system/page-objects/push-messaging.js
+++ b/web/tests/system/page-objects/push-messaging.js
@@ -44,4 +44,15 @@ PushMessaging.prototype.acceptDefaultAsk = function() {
     return this
 }
 
+PushMessaging.prototype.assertSubscribed = function() {
+    const self = this
+    this.browser
+        .execute(() => {
+            return window.Progressive.MessagingClient.LocalStorage.get('mobifyMessagingClientSubscriptionStatus')
+        }, [], ({value}) => {
+            self.browser.assert.equal(value, 'subscribed')
+        })
+    return this
+}
+
 export default PushMessaging

--- a/web/tests/system/page-objects/push-messaging.js
+++ b/web/tests/system/page-objects/push-messaging.js
@@ -47,11 +47,8 @@ PushMessaging.prototype.acceptDefaultAsk = function() {
 PushMessaging.prototype.assertSubscribed = function() {
     const self = this
     this.browser
-        // We have a pause here to allow Messaging Client to perform Service Worker
-        // operations that are asynchronous and take time - this may need to be
-        // increased
-        // .pause(2000)
         .executeAsync((_, done) => {
+            // 10 attempts; 200ms after each failure - 2 seconds total
             let attempt = 1
 
             const checkForSubscription = () => {

--- a/web/tests/system/workflows/push-subscribe.js
+++ b/web/tests/system/workflows/push-subscribe.js
@@ -35,6 +35,8 @@ export default {
 
         // This is the second page view, the DefaultAsk should be visible
         // by this point.
-        pushMessaging.acceptDefaultAsk()
+        pushMessaging
+            .acceptDefaultAsk()
+            .assertSubscribed()
     }
 }


### PR DESCRIPTION
Recent changes to `loader.js` broke the loading of Messaging Client as well as the order of app load and Init Promise initialization.

## Changes
- Since `loadAndInitMessagingClient` is no longer added to an array of deferred promises, remove "thunk" and just call the script load directly
- Add new method `addMessagingClientInitPromise` that sets up the Init Promise on window before `vendor.js` is loaded
- Modify error conditions in the script loading function - to avoid throwing multiple errors in console on error

## Todos
- [x] Test
- [x] +1

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- On the second page view, ensure you are shown the `DefaultAsk` messaging ask prompt (on supported devices, i.e. Chrome)
