### PR TITLE
Immutable.Map() as default in selectors for custom branches of the store

### DIFF
--- a/web/app/store/categories/selectors.js
+++ b/web/app/store/categories/selectors.js
@@ -23,7 +23,7 @@ export const getCategoryItemCount = createGetSelector(getSelectedCategory, 'item
 export const getCategoryTitle = createGetSelector(getSelectedCategory, 'title')
 export const getCategoryParentID = createGetSelector(getSelectedCategory, 'parentId', null)
 export const getCategorySearchTerm = createGetSelector(getSelectedCategory, 'searchTerm')
-export const getCategoryCustomContent = createGetSelector(getSelectedCategory, 'custom')
+export const getCategoryCustomContent = createGetSelector(getSelectedCategory, 'custom', Immutable.Map())
 export const getCategoryDescription = createGetSelector(getSelectedCategory, 'description')
 
 export const getCategoryParent = createSelector(

--- a/web/app/store/checkout/billing/selectors.js
+++ b/web/app/store/checkout/billing/selectors.js
@@ -16,4 +16,4 @@ export const getBillingInitialValues = createSelector(
     (billingAddress, billingSameAsShipping) => billingAddress.set('billingSameAsShipping', billingSameAsShipping)
 )
 
-export const getBillingAddressCustomContent = createGetSelector(getBillingAddress, 'custom')
+export const getBillingAddressCustomContent = createGetSelector(getBillingAddress, 'custom', Immutable.Map())

--- a/web/app/store/checkout/selectors.js
+++ b/web/app/store/checkout/selectors.js
@@ -34,5 +34,5 @@ export const getAvailableRegions = (formKey) => createSelector(
 
 export const getShippingMethods = createGetSelector(getCheckout, 'shippingMethods', Immutable.List())
 
-export const getCheckoutCustomContent = createGetSelector(getCheckout, 'custom')
-export const getLocationsCustomContent = createGetSelector(getLocations, 'custom')
+export const getCheckoutCustomContent = createGetSelector(getCheckout, 'custom', Immutable.Map())
+export const getLocationsCustomContent = createGetSelector(getLocations, 'custom', Immutable.Map())

--- a/web/app/store/checkout/shipping/selectors.js
+++ b/web/app/store/checkout/shipping/selectors.js
@@ -11,7 +11,7 @@ import {getShippingSavedAddressID} from '../../form/selectors'
 
 export const getShipping = createGetSelector(getCheckout, 'shipping', Immutable.Map())
 
-export const getShippingCustomContent = createGetSelector(getShipping, 'custom')
+export const getShippingCustomContent = createGetSelector(getShipping, 'custom', Immutable.Map())
 
 export const getSavedAddresses = createGetSelector(getCheckout, 'storedAddresses', Immutable.List())
 
@@ -84,4 +84,4 @@ export const getCity = createGetSelector(getShippingAddress, 'city')
 
 export const getIsInitialized = createGetSelector(getShippingAddress, 'isInitialized')
 
-export const getShippingAddressCustomContent = createGetSelector(getShippingAddress, 'custom')
+export const getShippingAddressCustomContent = createGetSelector(getShippingAddress, 'custom', Immutable.Map())

--- a/web/app/store/user/selectors.js
+++ b/web/app/store/user/selectors.js
@@ -1,10 +1,10 @@
 // /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 // /* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
 // /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
-
+import Immutable from 'immutable'
 import {createGetSelector} from 'reselect-immutable-helpers'
 import {getUser} from '../../store/selectors'
 
 export const getIsLoggedIn = createGetSelector(getUser, 'isLoggedIn')
 
-export const getUserCustomContent = createGetSelector(getUser, 'custom')
+export const getUserCustomContent = createGetSelector(getUser, 'custom', Immutable.Map())


### PR DESCRIPTION
I know that these things are getting moved into the SDK, but these fixes will need to be there when we move this code anyways so may as well get it in. Currently not having a default object returned by selectors that we are building other selectors off of can result in hard-to-track-down errors. We've seen this when building out a sample "My Account" page in training and the selector for custom user content doesn't return an empty Map() by default.

 **JIRA**: none
 **Linked PRs**: none

## Changes
- Return an `Immutable.Map()` as the default for selectors for the "custom" portions of the store.

## Todos
- [ ] ~~(if applicable) analytics events instrumented to measure impact of change~~

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Make sure nothing blows up?
- Build a selector that makes use of it like here? https://github.com/mobify/itg-training-merlins/compare/master...exercise3-milestone2-complete
