### PR TITLE
Relocate the setup of messaging promise in loader

### DIFF
--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -252,19 +252,19 @@ const attemptToInitializeApp = () => {
             src: getAssetUrl('static/js/jquery.min.js')
         })
 
-        loadScript({
-            id: 'progressive-web-main',
-            src: getAssetUrl('main.js')
-        })
-
         /**
-         * This must be called before vendor.js is loaded (or before the Webpack
-         * chunk that contains Messaging React components is loaded)
+         * This must be called before the Webpack chunk that contains Messaging
+         * React components is loaded - right now that's main.js.
          *
          * This creates a Promise: `window.Progressive.MessagingClientInitPromise`
          * which will be resolved or rejected later by the method `setupMessagingClient`
          */
         createGlobalMessagingClientInitPromise(messagingEnabled)
+
+        loadScript({
+            id: 'progressive-web-main',
+            src: getAssetUrl('main.js')
+        })
 
         loadScriptAsPromise({
             id: 'progressive-web-vendor',


### PR DESCRIPTION
So, I thought that `vendor.js` contains everything in `node_modules` but that doesn't seem to be the case. For safety, set up the Messaging promises before both `main.js` and `vendor.js` are loaded.

**Linked PR**: https://github.com/mobify/platform-scaffold/pull/855

## Changes
- Move `createGlobalMessagingClientInitPromise` above `main.js` and `vendor.js` loading in loader.js

## Todos
- [x] +1

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Messaging should be loaded, and DefaultAsk shown on the second page visit