### PR TITLE
Change where modify ga id is defined

### DIFF
--- a/web/app/store/index.js
+++ b/web/app/store/index.js
@@ -25,7 +25,7 @@ import analyticsManager from 'progressive-web-sdk/dist/analytics/analytics-manag
 
 analyticsManager.init({
     projectSlug: AJS_SLUG,              // eslint-disable-line no-undef
-    mobifyGAID: 'UA-53825302-1',
+    mobifyGAID: MOBIFY_GA_ID,
     ecommerceLibrary: 'ec',
     debug: DEBUG                        // eslint-disable-line no-undef
 })

--- a/web/app/store/index.js
+++ b/web/app/store/index.js
@@ -25,7 +25,7 @@ import analyticsManager from 'progressive-web-sdk/dist/analytics/analytics-manag
 
 analyticsManager.init({
     projectSlug: AJS_SLUG,              // eslint-disable-line no-undef
-    mobifyGAID: MOBIFY_GA_ID,
+    mobifyGAID: MOBIFY_GA_ID,           // eslint-disable-line no-undef
     ecommerceLibrary: 'ec',
     debug: DEBUG                        // eslint-disable-line no-undef
 })

--- a/web/app/store/index.js
+++ b/web/app/store/index.js
@@ -25,7 +25,7 @@ import analyticsManager from 'progressive-web-sdk/dist/analytics/analytics-manag
 
 analyticsManager.init({
     projectSlug: AJS_SLUG,              // eslint-disable-line no-undef
-    mobifyGAID: MOBIFY_GA_ID,           // eslint-disable-line no-undef
+    mobifyGAID: WEBPACK_MOBIFY_GA_ID,   // eslint-disable-line no-undef
     ecommerceLibrary: 'ec',
     debug: DEBUG                        // eslint-disable-line no-undef
 })

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "progressive-web-scaffold",
   "projectSlug": "progressive-web-scaffold",
   "aJSSlug": "merlinspotions-2",
+  "mobifyGAID": "UA-53825302-1",
   "messagingSiteId": "merlinspotions",
   "messagingEnabled": true,
   "repository": {

--- a/web/webpack/base.main.js
+++ b/web/webpack/base.main.js
@@ -74,7 +74,7 @@ const config = {
             // These are defined as string constants
             PROJECT_SLUG: `'${webPackageJson.projectSlug}'`,
             AJS_SLUG: `'${webPackageJson.aJSSlug}'`,
-            MOBIFY_GA_ID: `'${webPackageJson.mobifyGAID}'`
+            WEBPACK_MOBIFY_GA_ID: `'${webPackageJson.mobifyGAID}'`
         }),
         new webpack.LoaderOptionsPlugin({
             options: {

--- a/web/webpack/base.main.js
+++ b/web/webpack/base.main.js
@@ -73,7 +73,8 @@ const config = {
             MESSAGING_ENABLED: `${webPackageJson.messagingEnabled}`,
             // These are defined as string constants
             PROJECT_SLUG: `'${webPackageJson.projectSlug}'`,
-            AJS_SLUG: `'${webPackageJson.aJSSlug}'`
+            AJS_SLUG: `'${webPackageJson.aJSSlug}'`,
+            MOBIFY_GA_ID: `'${webPackageJson.mobifyGAID}'`
         }),
         new webpack.LoaderOptionsPlugin({
             options: {


### PR DESCRIPTION
Make sure Mobify GA ID is lives in the `package.json` so that platform generator can update it

 **JIRA**: https://mobify.atlassian.net/browse/MTT-652

## Changes
- move where ga-id is defined

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)

Expected: Mobify GA analytics are firing
