### PR TITLE
Make it Explicit when we're testing on the Production Environment

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -186,6 +186,12 @@ To verify that changes do not break the guest and registered checkout flows:
 npm run smoke-test
 ```
 
+To run end-to-end tests on the production environment:
+
+```
+npm run test:e2e-prod
+```
+
 ## Lighthouse tests
 
 You can run [Lighthouse](https://github.com/GoogleChrome/lighthouse) test against production with:

--- a/web/package.json
+++ b/web/package.json
@@ -138,6 +138,7 @@
     "test:build-size": "node tests/system/test-scripts/verify-build-size.js",
     "test:check-lighthouse-score": "node tests/system/test-scripts/check-lighthouse-score.js",
     "test:e2e": "cross-env NODE_ENV=test node ./node_modules/nightwatch/bin/runner.js -c ./tests/system/nightwatch-config.js --suiteRetries 1",
+    "test:e2e-prod": "cross-env NODE_ENV=production BABEL_ENV=test node ./node_modules/nightwatch/bin/runner.js -c ./tests/system/nightwatch-config.js --suiteRetries 1",
     "test:pwa-prod": "bash ./tests/system/test-scripts/lighthouse/lighthouse-prod.sh",
     "test:pwa-preview": "bash ./tests/system/test-scripts/lighthouse/lighthouse-preview.sh",
     "test:server": "bash ./scripts/test-server.sh",

--- a/web/tests/system/test-scripts/run-all-tests-on-ci.sh
+++ b/web/tests/system/test-scripts/run-all-tests-on-ci.sh
@@ -2,19 +2,6 @@
 set -o pipefail
 set -o nounset
 
-if git rev-parse ; then
-    # Get the current branch on CircleCI or local
-    CURRENT_BRANCH=${CIRCLE_BRANCH:-$(git branch | grep "*" | awk '{ print $2 }')}
-    # If current branch is master, we eliminate preview because we're testing production'
-    if [ "$CURRENT_BRANCH" == "master" ]; then
-      echo "On production branch, test server not needed."
-      export TEST_PROFILE=production
-    fi
-else
-    CURRENT_BRANCH=develop
-    export TEST_PROFILE=local
-fi
-
 #If the node total is 1, run all the tests sequentially. 
 if [ $CIRCLE_NODE_TOTAL -eq 1 ]; then
   echo 'Running lint'

--- a/web/tests/system/test-scripts/start-test-server.sh
+++ b/web/tests/system/test-scripts/start-test-server.sh
@@ -2,19 +2,7 @@
 set -o pipefail
 set -o nounset
 
-# Start the local test server if the current git branch is not master
-# or if there is no git branch.
-# Assumes that tests on master branch should run against production. 
-
-if git rev-parse ; then
-    # Get the current branch on CircleCI or local
-    CURRENT_BRANCH=${CIRCLE_BRANCH:-$(git branch | grep "*" | awk '{ print $2 }')}
-    if [ "$CURRENT_BRANCH" == "master" ]; then
-        echo "On production branch, test server not needed."   
-        exit 0 
-    fi
-fi
-
+# Start the local test server 
 # Kill background processes when this script exits.
 trap 'kill $(jobs -pr)' EXIT
 echo "Building project"

--- a/web/tests/system/workflows/guest-checkout.js
+++ b/web/tests/system/workflows/guest-checkout.js
@@ -43,7 +43,6 @@ export default {
         if (ENV === 'production') {
             browser.url(process.env.npm_package_siteUrl)
         } else {
-            console.log(ENV)
             console.log('Running preview against siteUrl.')
             browser.preview()
         }

--- a/web/tests/system/workflows/guest-checkout.js
+++ b/web/tests/system/workflows/guest-checkout.js
@@ -19,7 +19,7 @@ let pushMessaging
 
 const PRODUCT_LIST_INDEX = process.env.PRODUCT_LIST_INDEX || 2
 const PRODUCT_INDEX = process.env.PRODUCT_INDEX || 1
-const ENV = process.env.NODE_ENV || 'local'
+const ENV = process.env.NODE_ENV || 'test'
 
 export default {
     '@tags': ['checkout'],

--- a/web/tests/system/workflows/guest-checkout.js
+++ b/web/tests/system/workflows/guest-checkout.js
@@ -19,6 +19,7 @@ let pushMessaging
 
 const PRODUCT_LIST_INDEX = process.env.PRODUCT_LIST_INDEX || 2
 const PRODUCT_INDEX = process.env.PRODUCT_INDEX || 1
+const ENV = process.env.NODE_ENV || 'local'
 
 export default {
     '@tags': ['checkout'],
@@ -39,8 +40,14 @@ export default {
     // The following tests are conducted in sequence within the same session.
 
     'Checkout - Guest - Navigate to Home': (browser) => {
+        if (ENV === 'production') {
+            browser.url(process.env.npm_package_siteUrl)
+        } else {
+            console.log(ENV)
+            console.log('Running preview against siteUrl.')
+            browser.preview()
+        }
         browser
-            .preview()
             .waitForElementVisible(home.selectors.wrapper)
             .assert.visible(home.selectors.wrapper)
     },

--- a/web/tests/system/workflows/home-example.js
+++ b/web/tests/system/workflows/home-example.js
@@ -5,6 +5,7 @@
 import Home from '../page-objects/home'
 
 let home
+const ENV = process.env.NODE_ENV || 'test'
 
 // On the homepage, at least the following skip
 // links should be present on the page...
@@ -24,8 +25,13 @@ export default {
     },
 
     'Home Page': (browser) => {
+        if (ENV === 'production') {
+            browser.url(process.env.npm_package_siteUrl)
+        } else {
+            console.log('Running preview against siteUrl.')
+            browser.preview()
+        }
         browser
-            .preview()
             .waitForElementVisible(home.selectors.wrapper)
             .assert.visible(home.selectors.wrapper)
     },

--- a/web/tests/system/workflows/push-subscribe.js
+++ b/web/tests/system/workflows/push-subscribe.js
@@ -10,6 +10,7 @@ let home
 let pushMessaging
 
 const PRODUCT_LIST_INDEX = process.env.PRODUCT_LIST_INDEX || 2
+const ENV = process.env.NODE_ENV || 'test'
 
 export default {
     '@tags': ['messaging'],
@@ -24,8 +25,13 @@ export default {
     },
 
     'Push Subscribe - Home': (browser) => {
+        if (ENV === 'production') {
+            browser.url(process.env.npm_package_siteUrl)
+        } else {
+            console.log('Running preview against siteUrl.')
+            browser.preview()
+        }
         browser
-            .preview()
             .waitForElementVisible(home.selectors.wrapper)
             .assert.visible(home.selectors.wrapper)
     },

--- a/web/tests/system/workflows/registered-checkout.js
+++ b/web/tests/system/workflows/registered-checkout.js
@@ -19,6 +19,7 @@ let pushMessaging
 
 const PRODUCT_LIST_INDEX = process.env.PRODUCT_LIST_INDEX || 2
 const PRODUCT_INDEX = process.env.PRODUCT_INDEX || 1
+const ENV = process.env.NODE_ENV || 'test'
 
 export default {
     '@tags': ['checkout'],
@@ -40,8 +41,13 @@ export default {
     // The following tests are conducted in sequence within the same session.
 
     'Checkout - Registered - Navigate to Home': (browser) => {
+        if (ENV === 'production') {
+            browser.url(process.env.npm_package_siteUrl)
+        } else {
+            console.log('Running preview against siteUrl.')
+            browser.preview()
+        }
         browser
-            .preview()
             .waitForElementVisible(home.selectors.wrapper)
             .assert.visible(home.selectors.wrapper)
     },


### PR DESCRIPTION
To reduce confusion, we want to make the test commands explicit when we're testing on production.

## Changes
- `npm run test:e2e-prod` will test without preview the siteUrl in the package.json
- Removes the 'magic' of our setup scripts which detects git branch and associate master with the production environment 

## Todo
- Update Readme
- Update this with the new nightwatch-commands

## How to test-drive this PR
- npm run test:e2e-prod
