### PR TITLE
remove this props, does not support on carousel

### DIFF
--- a/amp/app/containers/product-details/partials/product-details-carousel.jsx
+++ b/amp/app/containers/product-details/partials/product-details-carousel.jsx
@@ -9,15 +9,11 @@ import Carousel from '../../../components/carousel'
 // Selectors
 import {getProductImages} from 'progressive-web-sdk/dist/store/products/selectors'
 
-import {staticURL} from '../../../utils'
-
 const ProductDetailsCarousel = ({images}) => {
 
     return (
         <Carousel
             id="product-details-carousel"
-            previousIcon={staticURL('chevron-left')}
-            nextIcon={staticURL('chevron-right')}
             className="a--frame a--side-controls t-product-details__carousel u-padding-md u-bg-color-neutral-10"
             height="330"
             width="330"


### PR DESCRIPTION
Fix carousel props on PDP: `previousIcon` and `nextIcon` does not work with `<Carousel>`

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](http://localhost:3000/potions/eye-of-newt.html)
