### PR TITLE
Skip the rest of the tests if a product is sold out

### DIFF
--- a/web/tests/system/page-objects/product-details.js
+++ b/web/tests/system/page-objects/product-details.js
@@ -12,14 +12,23 @@ const selectors = {
 const ProductDetails = function(browser) {
     this.browser = browser
     this.selectors = selectors
+    this.inStock = true
 }
 
 ProductDetails.prototype.addItemToCart = function() {
     // Add an item to the cart
+    const self = this
     this.browser
         .log('Adding item to cart')
-        .waitForElementVisible(selectors.addItem)
-        .click(selectors.addItem)
+        .element('css selector', selectors.addItem, (result) => {
+            if (result.value && result.value.ELEMENT) {
+                self.browser
+                    .waitForElementVisible(selectors.addItem)
+                    .click(selectors.addItem)
+            } else {
+                self.inStock = false
+            }
+        })
         .waitUntilMobified()
     return this
 }

--- a/web/tests/system/workflows/guest-checkout.js
+++ b/web/tests/system/workflows/guest-checkout.js
@@ -18,7 +18,7 @@ let checkout
 let pushMessaging
 
 const PRODUCT_LIST_INDEX = process.env.PRODUCT_LIST_INDEX || 2
-const PRODUCT_INDEX = process.env.PRODUCT_INDEX || 1
+const PRODUCT_INDEX = process.env.PRODUCT_INDEX || 2
 const ENV = process.env.NODE_ENV || 'test'
 
 export default {
@@ -69,47 +69,56 @@ export default {
             .assert.visible(productDetails.selectors.productDetailsTemplateIdentifier)
     },
 
-    'Checkout - Guest - Add item to Shopping Cart': (browser) => {
+    'Checkout - Guest - Add item to Shopping Cart': () => {
         productDetails.addItemToCart()
-        browser
-            .waitForElementVisible(productDetails.selectors.itemAdded)
-            .assert.visible(productDetails.selectors.itemAdded)
     },
 
     'Checkout - Guest - Navigate from ProductDetails to Cart': (browser) => {
-        productDetails.navigateToCart()
-        browser
-            .waitForElementVisible(cart.selectors.cartTemplateIdentifier)
-            .assert.visible(cart.selectors.cartTemplateIdentifier)
+        if (productDetails.inStock) {
+            productDetails.navigateToCart()
+            browser
+                .waitForElementVisible(cart.selectors.cartTemplateIdentifier)
+                .assert.visible(cart.selectors.cartTemplateIdentifier)
+        } else {
+            browser.log('Item is out of stock.')
+        }
     },
 
     'Checkout - Guest - Navigate from Cart to Checkout': (browser) => {
-        cart.navigateToCheckout()
-        browser
-            .waitForElementVisible(checkout.selectors.checkoutTemplateIdentifier)
-            .assert.visible(checkout.selectors.checkoutTemplateIdentifier)
+        if (productDetails.inStock) {
+            cart.navigateToCheckout()
+            browser
+                .waitForElementVisible(checkout.selectors.checkoutTemplateIdentifier)
+                .assert.visible(checkout.selectors.checkoutTemplateIdentifier)
+        }
     },
 
     'Checkout - Guest - Fill out Guest Checkout Shipping Info form': (browser) => {
-        checkout.fillShippingInfo()
-        browser
-            // Phone field should have numeric input type
-            .waitForElementVisible(`${checkout.selectors.phone}[type="tel"]`)
-            .waitForElementVisible(checkout.selectors.address)
-            .assert.valueContains(checkout.selectors.address, checkout.userData.address)
+        if (productDetails.inStock) {
+            checkout.fillShippingInfo()
+            browser
+                // Phone field should have numeric input type
+                .waitForElementVisible(`${checkout.selectors.phone}[type="tel"]`)
+                .waitForElementVisible(checkout.selectors.address)
+                .assert.valueContains(checkout.selectors.address, checkout.userData.address)
+        }
     },
 
     'Checkout - Guest - Fill out Guest Checkout Payment Details form': (browser) => {
-        checkout.continueToPayment()
-        checkout.fillPaymentInfo()
-        browser
-            .waitForElementVisible(checkout.selectors.cvv)
-            .assert.valueContains(checkout.selectors.cvv, checkout.userData.cvv)
+        if (productDetails.inStock) {
+            checkout.continueToPayment()
+            checkout.fillPaymentInfo()
+            browser
+                .waitForElementVisible(checkout.selectors.cvv)
+                .assert.valueContains(checkout.selectors.cvv, checkout.userData.cvv)
+        }
     },
 
     'Checkout - Guest - Verify Place Your Order button is visible': (browser) => {
-        browser
-            .waitForElementVisible(checkout.selectors.placeOrder)
-            .assert.visible(checkout.selectors.placeOrder)
+        if (productDetails.inStock) {
+            browser
+                .waitForElementVisible(checkout.selectors.placeOrder)
+                .assert.visible(checkout.selectors.placeOrder)
+        }
     }
 }

--- a/web/tests/system/workflows/guest-checkout.js
+++ b/web/tests/system/workflows/guest-checkout.js
@@ -80,7 +80,7 @@ export default {
                 .waitForElementVisible(cart.selectors.cartTemplateIdentifier)
                 .assert.visible(cart.selectors.cartTemplateIdentifier)
         } else {
-            browser.log('Item is out of stock. Try changing PRODUCT_INDEX. It is currently ' + PRODUCT_INDEX)
+            browser.log(`Item is out of stock. Try changing PRODUCT_INDEX. It is currently ${PRODUCT_INDEX}`)
         }
     },
 

--- a/web/tests/system/workflows/guest-checkout.js
+++ b/web/tests/system/workflows/guest-checkout.js
@@ -80,7 +80,7 @@ export default {
                 .waitForElementVisible(cart.selectors.cartTemplateIdentifier)
                 .assert.visible(cart.selectors.cartTemplateIdentifier)
         } else {
-            browser.log('Item is out of stock.')
+            browser.log('Item is out of stock. Try changing PRODUCT_INDEX. It is currently ' + PRODUCT_INDEX)
         }
     },
 

--- a/web/tests/system/workflows/registered-checkout.js
+++ b/web/tests/system/workflows/registered-checkout.js
@@ -81,7 +81,7 @@ export default {
                 .waitForElementVisible(cart.selectors.cartTemplateIdentifier)
                 .assert.visible(cart.selectors.cartTemplateIdentifier)
         } else {
-            browser.log('Item is out of stock.')
+            browser.log('Item is out of stock. Try changing PRODUCT_INDEX. It is currently ' + PRODUCT_INDEX)
         }
     },
 

--- a/web/tests/system/workflows/registered-checkout.js
+++ b/web/tests/system/workflows/registered-checkout.js
@@ -18,7 +18,7 @@ let checkout
 let pushMessaging
 
 const PRODUCT_LIST_INDEX = process.env.PRODUCT_LIST_INDEX || 2
-const PRODUCT_INDEX = process.env.PRODUCT_INDEX || 1
+const PRODUCT_INDEX = process.env.PRODUCT_INDEX || 2
 const ENV = process.env.NODE_ENV || 'test'
 
 export default {
@@ -70,52 +70,61 @@ export default {
             .assert.visible(productDetails.selectors.productDetailsTemplateIdentifier)
     },
 
-    'Checkout - Registered - Add item to Shopping Cart': (browser) => {
+    'Checkout - Registered - Add item to Shopping Cart': () => {
         productDetails.addItemToCart()
-        browser
-            .waitForElementVisible(productDetails.selectors.itemAdded)
-            .assert.visible(productDetails.selectors.itemAdded)
     },
 
     'Checkout - Registered - Navigate from ProductDetails to Cart': (browser) => {
-        productDetails.navigateToCart()
-        browser
-            .waitForElementVisible(cart.selectors.cartTemplateIdentifier)
-            .assert.visible(cart.selectors.cartTemplateIdentifier)
+        if (productDetails.inStock) {
+            productDetails.navigateToCart()
+            browser
+                .waitForElementVisible(cart.selectors.cartTemplateIdentifier)
+                .assert.visible(cart.selectors.cartTemplateIdentifier)
+        }
     },
 
     'Checkout - Registered - Navigate from Cart to Checkout': (browser) => {
-        cart.navigateToCheckout()
-        browser
-            .waitForElementVisible(checkout.selectors.checkoutTemplateIdentifier)
-            .assert.visible(checkout.selectors.checkoutTemplateIdentifier)
-            // Email field should have email input type
-            .waitForElementVisible(`${checkout.selectors.email}[type="email"]`)
+        if (productDetails.inStock) {
+            cart.navigateToCheckout()
+            browser
+                .waitForElementVisible(checkout.selectors.checkoutTemplateIdentifier)
+                .assert.visible(checkout.selectors.checkoutTemplateIdentifier)
+                // Email field should have email input type
+                .waitForElementVisible(`${checkout.selectors.email}[type="email"]`)
+        }
     },
 
     'Checkout - Registered - Continue to Registered Checkout': (browser) => {
-        checkout.continueAsRegistered()
-        browser
-            .waitForElementVisible(checkout.selectors.checkoutTemplateIdentifier)
-            .assert.visible(checkout.selectors.checkoutTemplateIdentifier)
+        if (productDetails.inStock) {
+            checkout.continueAsRegistered()
+            browser
+                .waitForElementVisible(checkout.selectors.checkoutTemplateIdentifier)
+                .assert.visible(checkout.selectors.checkoutTemplateIdentifier)
+        }
     },
 
     'Checkout - Registered - Choose shipping info': (browser) => {
-        checkout.chooseShippingInfo()
-        browser.waitForElementVisible(`${checkout.selectors.addressListOption} .pw--checked`)
+        if (productDetails.inStock) {
+            checkout.chooseShippingInfo()
+            browser.waitForElementVisible(`${checkout.selectors.addressListOption} .pw--checked`)
+        }
     },
 
     'Checkout - Registered - Fill out Registered Checkout Payment Details form': (browser) => {
-        checkout.continueToPayment()
-        checkout.fillPaymentInfo()
-        browser
-            .waitForElementVisible(checkout.selectors.cvv)
-            .assert.valueContains(checkout.selectors.cvv, checkout.userData.cvv)
+        if (productDetails.inStock) {
+            checkout.continueToPayment()
+            checkout.fillPaymentInfo()
+            browser
+                .waitForElementVisible(checkout.selectors.cvv)
+                .assert.valueContains(checkout.selectors.cvv, checkout.userData.cvv)
+        }
     },
 
     'Checkout - Registered - Verify Submit Order button is visible': (browser) => {
-        browser
-            .waitForElementVisible(checkout.selectors.placeOrder)
-            .assert.visible(checkout.selectors.placeOrder)
+        if (productDetails.inStock) {
+            browser
+                .waitForElementVisible(checkout.selectors.placeOrder)
+                .assert.visible(checkout.selectors.placeOrder)
+        }
     }
 }

--- a/web/tests/system/workflows/registered-checkout.js
+++ b/web/tests/system/workflows/registered-checkout.js
@@ -81,7 +81,7 @@ export default {
                 .waitForElementVisible(cart.selectors.cartTemplateIdentifier)
                 .assert.visible(cart.selectors.cartTemplateIdentifier)
         } else {
-            browser.log('Item is out of stock. Try changing PRODUCT_INDEX. It is currently ' + PRODUCT_INDEX)
+            browser.log(`Item is out of stock. Try changing PRODUCT_INDEX. It is currently ${PRODUCT_INDEX}`)
         }
     },
 

--- a/web/tests/system/workflows/registered-checkout.js
+++ b/web/tests/system/workflows/registered-checkout.js
@@ -80,6 +80,8 @@ export default {
             browser
                 .waitForElementVisible(cart.selectors.cartTemplateIdentifier)
                 .assert.visible(cart.selectors.cartTemplateIdentifier)
+        } else {
+            browser.log('Item is out of stock.')
         }
     },
 


### PR DESCRIPTION
## Changes
- Keep track of whether the product is in stock or not
- Condition the rest of the tests (after adding item to cart) on whether the product is in stock

## How to test-drive this PR
- Rebuild https://circleci.com/gh/mobify/platform-scaffold/tree/e2e-sold-out
- If testing the sold out case, set `PRODUCT_LIST_INDEX` and `PRODUCT_INDEX` to 2