### PR TITLE
change input font-size to 16px

### DIFF
--- a/web/app/styles/base/_forms.scss
+++ b/web/app/styles/base/_forms.scss
@@ -48,7 +48,7 @@ label,
 textarea,
 select {
     font-family: $font-family;
-    font-size: $font-size;
+    font-size: $medium-font-size;
 }
 
 label {

--- a/web/app/styles/base/_forms.scss
+++ b/web/app/styles/base/_forms.scss
@@ -15,6 +15,7 @@ $base__radio-checkmark: 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2
 //    elements.
 // 5. Correct font properties not being inherited.
 // 6. Address margins set differently in Firefox 4+, Safari, and Chrome.
+// 7. Set font-size to 16px to avoid zooming in on iOS
 
 fieldset {
     min-width: 0;
@@ -29,7 +30,7 @@ input {
     color: inherit; // 4
     font: inherit; // 5
     font-family: $font-family;
-    font-size: $medium-font-size;
+    font-size: $medium-font-size; // 7
     line-height: normal; // 1
 
     &::-moz-focus-inner {

--- a/web/app/styles/base/_forms.scss
+++ b/web/app/styles/base/_forms.scss
@@ -15,7 +15,7 @@ $base__radio-checkmark: 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2
 //    elements.
 // 5. Correct font properties not being inherited.
 // 6. Address margins set differently in Firefox 4+, Safari, and Chrome.
-// 7. Set font-size to 16px to avoid zooming in on iOS
+// 7. Set font-size to 16px to avoid zooming in on iOS (https://stackoverflow.com/questions/11064237/prevent-iphone-from-zooming-form)
 
 fieldset {
     min-width: 0;

--- a/web/app/styles/base/_forms.scss
+++ b/web/app/styles/base/_forms.scss
@@ -292,8 +292,7 @@ button,
     }
 }
 
-html input[type="button"],
-// 6
+html input[type="button"], // 6
 input[type="reset"] {
     -webkit-appearance: button; // 7
 }

--- a/web/app/styles/base/_forms.scss
+++ b/web/app/styles/base/_forms.scss
@@ -28,6 +28,8 @@ input {
 
     color: inherit; // 4
     font: inherit; // 5
+    font-family: $font-family;
+    font-size: $medium-font-size;
     line-height: normal; // 1
 
     &::-moz-focus-inner {
@@ -43,12 +45,11 @@ textarea {
     font: inherit; // 5
 }
 
-input,
 label,
 textarea,
 select {
     font-family: $font-family;
-    font-size: $medium-font-size;
+    font-size: $font-size;
 }
 
 label {
@@ -291,7 +292,8 @@ button,
     }
 }
 
-html input[type="button"], // 6
+html input[type="button"],
+// 6
 input[type="reset"] {
     -webkit-appearance: button; // 7
 }


### PR DESCRIPTION
When focusing on input fields on Merlins, the interface zooms

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1469

## Changes
- change input font-size to 16px

## Todos
- [ ] ~(if applicable) analytics events instrumented to measure impact of change~
- [ ] Add a high-level description of your changes to the CHANGELOG.md, including a link to the PR with your changes

## How to test-drive this PR
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1) on iphone
- open search and check it doesn't zoom in
