### PR TITLE
Adds `npm start` to package.json npm scripts

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -136,6 +136,7 @@
     "styleguide": "styleguidist --config webpack/styleguide.config.js server",
     "save-credentials": "sdk-save-credentials",
     "smoke-test": "bash ./tests/e2e/test-scripts/smoke-test.sh",
+    "start": "sdk-get-routes && sdk-create-hash-manifest && node ./dev-server/index.js",
     "test": "cross-env NODE_ENV=test jest",
     "test:all": "npm run lint && npm test -- --coverage",
     "test:check-lighthouse-score": "node tests/performance/lighthouse/check-lighthouse-score.js",


### PR DESCRIPTION
# `npm start`
## `npm start`
### `npm start`
#### `npm start`
##### `npm start`
###### `npm start`


Note: This PR is additive, we won't be removing `npm run dev` yet