### PR TITLE
Amp 97 configures amp ga in generator

### DIFF
--- a/amp/app/main.js
+++ b/amp/app/main.js
@@ -45,10 +45,10 @@ const render = (req, res, store, component) => {
         <ampSDK.AmpContext trackRender={components.add.bind(components)}>
             <Provider store={store}>
                 <App>
-                  <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.gaAccount} />
-                  {ampPackageJson.ampgaAccount !== null &&
-                  <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.ampgaAccount} />}
-                  {React.createElement(component, {}, null)}
+                    <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.gaAccount} />
+                    {ampPackageJson.ampgaAccount !== null &&
+                    <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.ampgaAccount} />}
+                    {React.createElement(component, {}, null)}
                 </App>
             </Provider>
         </ampSDK.AmpContext>

--- a/amp/app/main.js
+++ b/amp/app/main.js
@@ -47,7 +47,7 @@ const render = (req, res, store, component) => {
                 <App>
                     <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.gaAccount} />
                     {ampPackageJson.ampgaAccount !== null &&
-                    <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.ampgaAccount} />}
+                    <Analytics projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.ampgaAccount} />}
                     {React.createElement(component, {}, null)}
                 </App>
             </Provider>

--- a/amp/app/main.js
+++ b/amp/app/main.js
@@ -34,6 +34,16 @@ const fonts = [
     '<link href="https://fonts.googleapis.com/css?family=Oswald:200,400" rel="stylesheet">'
 ]
 
+const addAnalytics = () => {
+  return (
+    <div>
+      <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.gaAccount} />
+      {ampPackageJson.ampgaAccount !== null &&
+        <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.ampgaAccount} />
+      }
+    </div>
+  )
+}
 
 const getFullUrl = (req) => {
     return `${ampPackageJson.siteUrl}${req.url}`
@@ -46,7 +56,7 @@ const render = (req, res, store, component) => {
         <ampSDK.AmpContext trackRender={components.add.bind(components)}>
             <Provider store={store}>
                 <App>
-                    <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.gaAccount} />
+                    {addAnalytics()}
                     {React.createElement(component, {}, null)}
                 </App>
             </Provider>

--- a/amp/app/main.js
+++ b/amp/app/main.js
@@ -47,7 +47,7 @@ const render = (req, res, store, component) => {
                 <App>
                     <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.gaAccount} />
                     {ampPackageJson.ampgaAccount !== null &&
-                    <Analytics projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.ampgaAccount} />}
+                    <Analytics templateName={component.templateName} gaAccount={ampPackageJson.ampgaAccount} />}
                     {React.createElement(component, {}, null)}
                 </App>
             </Provider>

--- a/amp/app/main.js
+++ b/amp/app/main.js
@@ -34,17 +34,6 @@ const fonts = [
     '<link href="https://fonts.googleapis.com/css?family=Oswald:200,400" rel="stylesheet">'
 ]
 
-const addAnalytics = () => {
-  return (
-    <div>
-      <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.gaAccount} />
-      {ampPackageJson.ampgaAccount !== null &&
-        <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.ampgaAccount} />
-      }
-    </div>
-  )
-}
-
 const getFullUrl = (req) => {
     return `${ampPackageJson.siteUrl}${req.url}`
 }
@@ -56,8 +45,10 @@ const render = (req, res, store, component) => {
         <ampSDK.AmpContext trackRender={components.add.bind(components)}>
             <Provider store={store}>
                 <App>
-                    {addAnalytics()}
-                    {React.createElement(component, {}, null)}
+                  <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.gaAccount} />
+                  {ampPackageJson.ampgaAccount !== null &&
+                  <Analytics templateName={component.templateName} projectSlug={ampPackageJson.cloudSlug} gaAccount={ampPackageJson.ampgaAccount} />}
+                  {React.createElement(component, {}, null)}
                 </App>
             </Provider>
         </ampSDK.AmpContext>


### PR DESCRIPTION
**JIRA**: https://mobify.atlassian.net/browse/AMP-97
**Status**: WIP - Opened for visibility
**Reviewers**: @kschmidtdev @olibrook 

## Changes
- Add new analytics component to AMP App to account for new amp-ga-id if available

## How to test-drive this PR
- Edit `./amp/package.json` to add new field 'ampgaAccount` and set it to a random id.
- `npm run dev`
- Open the networks tab on chrome debugger and visit `localhost:3000/potions.html` and ensure two analytics requests are sent. You can search for your newly set ID or `ampgaAccount` to find the new analytics request.

TODO:
- [ ] Get 👍 