### PR TITLE
Feature/mbfycnct 21 register user command

### DIFF
--- a/web/app/connectors/hybris-connector/account/commands.js
+++ b/web/app/connectors/hybris-connector/account/commands.js
@@ -9,22 +9,17 @@ import {setLoggedIn} from 'progressive-web-sdk/dist/integration-manager/results'
 import {receiveUserEmail} from 'progressive-web-sdk/dist/integration-manager/checkout/results'
 import {getAuthEndPoint, getHomeURL} from '../config'
 
-import {deleteSession, storeAuthTokenAndExpiration, storeUserType, deleteBasketID, USER_REGISTERED} from '../utils'
+import {deleteSession, makeApiRequest, makeUnAuthenticatedApiRequest, storeAuthTokenAndExpiration, storeUserType, deleteBasketID, USER_REGISTERED} from '../utils'
 import {fetchNavigationData} from '../app/commands'
 
-/* eslint-disable no-unused-vars */
-
-export const initLoginPage = (url, routeName) => (dispatch) => {
-    console.log('[Hybris Connector] Called initLoginPage stub with parameters:', url, routeName)
+const initLoginData = () => (dispatch) => {
     dispatch(setSigninLoaded())
-    return Promise.resolve()
-}
-
-export const initRegisterPage = (url, routeName) => (dispatch) => {
-    console.log('[Hybris Connector] Called initRegisterPage stub with parameters:', url, routeName)
     dispatch(setRegisterLoaded())
     return Promise.resolve()
 }
+
+export const initLoginPage = initLoginData
+export const initRegisterPage = initLoginData
 
 export const navigateToSection = (router, routes, sectionName) => (dispatch) => {
     console.log('[Hybris Connector] Called navigateToSection stub with parameters:', router, routes, sectionName)
@@ -32,9 +27,10 @@ export const navigateToSection = (router, routes, sectionName) => (dispatch) => 
 }
 
 export const login = (username, password) => (dispatch) => {
-    let responseHeaders
+    /* eslint-disable no-unused-vars */
     let basketContents
-    let customerID
+    /* eslint-enable no-unused-vars */
+
     const body = {
         client_id: 'mobile_android',
         grant_type: 'password',
@@ -50,10 +46,7 @@ export const login = (username, password) => (dispatch) => {
             // Actual login call
             return makeFormEncodedRequest(getAuthEndPoint(), body, {method: 'POST'})
         })
-        .then((response) => {
-            responseHeaders = response.headers
-            return response.json()
-        })
+        .then((response) => response.json())
         .then((responseJSON) => {
             if (responseJSON.error) {
                 let errorMessage = 'Username or password is incorrect'
@@ -63,35 +56,34 @@ export const login = (username, password) => (dispatch) => {
                 throw new SubmissionError({_error: errorMessage})
             }
             storeAuthTokenAndExpiration(responseJSON)
-            customerID = responseJSON.uid
             dispatch(setLoggedIn(true))
             dispatch(receiveUserEmail(responseJSON.uid))
             storeUserType(USER_REGISTERED)
             dispatch(fetchNavigationData())
             return deleteBasketID()
         })
-            /*
+        /*
         // Check if the user has a basket already
-        .then(() => makeApiRequest(`/customers/${customerID}/baskets`, {method: 'GET'}))
+        .then(() => makeApiRequest(`/users/current/carts`, {method: 'GET'}))
         .then((response) => response.json())
-        .then(({baskets}) => {
-            if (!baskets || baskets.length === 0) {
-                return createBasket(basketContents)
-            }
+        .then(({carts: baskets}) => {
+             if (!baskets || baskets.length === 0) {
+             return createBasket(basketContents)
+             }
 
-            const basketID = baskets[0].basket_id
-            storeBasketID(basketID)
-            if (!basketContents.product_items) {
-                // There is no basket to merge, so return the existing one
-                return Promise.resolve(baskets[0])
-            }
-            // update basket with contents (product_items)
-            return makeApiJsonRequest(
-                `/baskets/${basketID}/items`,
-                basketContents.product_items,
-                {method: 'POST'}
-            )
-                .then(checkForResponseFault)
+             const basketID = baskets[0].basket_id
+             storeBasketID(basketID)
+             if (!basketContents.product_items) {
+             // There is no basket to merge, so return the existing one
+             return Promise.resolve(baskets[0])
+             }
+             // update basket with contents (product_items)
+             return makeApiJsonRequest(
+             `/baskets/${basketID}/items`,
+             basketContents.product_items,
+             {method: 'POST'}
+             )
+             .then(checkForResponseFault)
         })
         .then((basket) => dispatch(handleCartData(basket)))
         */
@@ -109,12 +101,71 @@ export const logout = () => (dispatch) => {
     return Promise.resolve()
 }
 
-export const registerUser = (firstname, lastname, email, password) => (dispatch) => {
-    console.log('[Hybris Connector] Called registerUser stub with parameters:', firstname, lastname, email, password)
+const mapHybrisToMobifyParam = (param) => {
+    switch (param) {
+        case 'email':
+            return 'uid'
+        case 'password':
+            return 'password'
+        case 'firstname':
+            return 'firstName'
+        case 'lastname':
+            return 'lastName'
+        default:
+            return false
+    }
+}
 
-    // This promise should resolve to the URL of the account page
-    // to redirect the user to.
-    return Promise.resolve()
+export const registerUser = (firstname, lastname, email, password) => (dispatch) => {
+    return makeUnAuthenticatedApiRequest('/titles')
+        .then((response) => response.json())
+        .then((json) => json)
+        .then(({titles}) => {
+            if (!titles || !titles.length) {
+                throw new SubmissionError({_error: 'Unable to create account.'})
+            }
+            const titleCode = titles[0].code
+            const requestOptions = {
+                method: 'POST',
+                body: JSON.stringify({
+                    uid: email,
+                    password,
+                    firstName: firstname,
+                    lastName: lastname,
+                    titleCode
+                })
+            }
+            return makeApiRequest('/users', requestOptions)
+        })
+        .then((response) => {
+            let result
+            if (response.status === 201) {
+                result = Promise.resolve(response)
+            } else {
+                result = response.json()
+            }
+            return result
+        })
+        .then((response) => {
+            if (response.status !== 201) {
+                const errors = response.errors || {}
+                const errorData = errors.reduce((acc, err) => {
+                    if (err.type === 'DuplicateUidError') {
+                        acc.email = 'This email already exists.'
+                    } else {
+                        const param = mapHybrisToMobifyParam(err.subject)
+                        if (param) {
+                            acc[param] = acc[param] || err.message
+                        }
+                    }
+                    return acc
+                }, {})
+                errorData._error = 'Unable to create account.'
+                throw new SubmissionError(errorData)
+            }
+            // Creating a user doesn't sign them in automatically, so dispatch the login command
+            return dispatch(login(email, password, true))
+        })
 }
 
 export const updateShippingAddress = (formValues) => (dispatch) => {

--- a/web/app/connectors/hybris-connector/account/utils.js
+++ b/web/app/connectors/hybris-connector/account/utils.js
@@ -1,0 +1,35 @@
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+/* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
+/* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+
+const mapHybrisToMobifyParam = (param) => {
+    switch (param) {
+        case 'email':
+            return 'uid'
+        case 'password':
+            return 'password'
+        case 'firstname':
+            return 'firstName'
+        case 'lastname':
+            return 'lastName'
+        default:
+            return false
+    }
+}
+
+export const getRegisterUserErrorData = (response) => {
+    const errors = response.errors || {}
+    const errorData = errors.reduce((acc, err) => {
+        if (err.type === 'DuplicateUidError') {
+            acc.email = 'This email already exists.'
+        } else {
+            const param = mapHybrisToMobifyParam(err.subject)
+            if (param) {
+                acc[param] = acc[param] || err.message
+            }
+        }
+        return acc
+    }, {})
+    errorData._error = 'Unable to create account.'
+    return errorData
+}


### PR DESCRIPTION
Added registerUser connector 

 **JIRA**: [MBFYCNCT-21](https://thinkwrap.jira.com/browse/MBFYCNCT-21)

## Changes
- Added utils.js to provide a getRegisterUserErrorData method that returns an object with the Hybris errors parsed so that the redux-form can properly show the errors to the customer. To test this functionality:
- Try to add an existing user. The message 'This email already exists' is shown (this message is only shown if there are no other validation errors)
- Try to add a non-valid hybris password. It will show messages as: 'Password should contain at least one number', 'Password should contain at least one uppercase character' or 'Password should contain at least one special character'

