### PR TITLE
SFCC Data API, support multiple levels of categories

### DIFF
--- a/web/app/connectors/_sfcc-connector/app/commands.js
+++ b/web/app/connectors/_sfcc-connector/app/commands.js
@@ -36,9 +36,10 @@ import {
     LOGGED_IN_NAV
 } from '../../../modals/navigation/constants'
 
+const CATALOG = 'storefront-catalog-en'
 
 export const fetchNavigationData = () => (dispatch) => {
-    return utils.makeUnAuthenticatedApiRequest('/categories/root?levels=2', {method: 'GET'})
+    return utils.makeDataApiRequest(`/catalogs/${CATALOG}/categories?count=1000&select=(**)`, {method: 'GET'})
         .then((response) => response.json())
         .then(({categories}) => {
             const navData = parseCategories(categories)

--- a/web/app/connectors/_sfcc-connector/config.js
+++ b/web/app/connectors/_sfcc-connector/config.js
@@ -3,22 +3,14 @@
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 import {buildQueryString} from '../../utils/utils'
 
-const API_TYPE = 'shop'
+const SHOP_API = 'shop'
+const DATA_API = 'data'
 const API_VERSION = 'v17_4'
-const CLIENT_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-const CLIENT_PASSWORD = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-const BUSINESS_MANAGER_USER = 'public-data-api-access'
-const BUSINESS_MANAGER_PASSWORD = '6sL!LJOk'
 const GRANT_TYPE = 'urn:demandware:params:oauth:grant-type:client-id:dwsid:dwsecuretoken'
 
 export const SEARCH_URL = '/catalogsearch/result/'
 
-let config = {
-    clientId: CLIENT_ID,
-    clientPassword: CLIENT_PASSWORD,
-    businessManagerUser: BUSINESS_MANAGER_USER,
-    businessManagerPassword: BUSINESS_MANAGER_PASSWORD
-}
+let config = {}
 
 export const registerConfig = (cfg) => {
     config = cfg
@@ -27,8 +19,9 @@ export const registerConfig = (cfg) => {
 export const getSiteID = () => config.siteID
 
 
-export const getApiEndPoint = () => `/s/${getSiteID()}/dw/${API_TYPE}/${API_VERSION}`
-export const getOAuthEndPoint = () => `/dw/oauth2/access_token?client_id=${config.clientId}&grant_type=${GRANT_TYPE}`
+export const getApiEndPoint = () => `/s/${getSiteID()}/dw/${SHOP_API}/${API_VERSION}`
+export const getDataApiEndPoint = () => `/s/-/dw/${DATA_API}/${API_VERSION}`
+export const getOAuthEndPoint = () => `/dw/oauth2/access_token?client_id=${config.dataAPIClientID}&grant_type=${GRANT_TYPE}`
 
 export const getRequestHeaders = () => ({
     'Content-Type': 'application/json',

--- a/web/app/connectors/_sfcc-connector/config.js
+++ b/web/app/connectors/_sfcc-connector/config.js
@@ -5,10 +5,20 @@ import {buildQueryString} from '../../utils/utils'
 
 const API_TYPE = 'shop'
 const API_VERSION = 'v17_4'
+const CLIENT_ID = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const CLIENT_PASSWORD = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+const BUSINESS_MANAGER_USER = 'public-data-api-access'
+const BUSINESS_MANAGER_PASSWORD = '6sL!LJOk'
+const GRANT_TYPE = 'urn:demandware:params:oauth:grant-type:client-id:dwsid:dwsecuretoken'
 
 export const SEARCH_URL = '/catalogsearch/result/'
 
-let config = {}
+let config = {
+    clientId: CLIENT_ID,
+    clientPassword: CLIENT_PASSWORD,
+    businessManagerUser: BUSINESS_MANAGER_USER,
+    businessManagerPassword: BUSINESS_MANAGER_PASSWORD
+}
 
 export const registerConfig = (cfg) => {
     config = cfg
@@ -16,11 +26,18 @@ export const registerConfig = (cfg) => {
 
 export const getSiteID = () => config.siteID
 
+
 export const getApiEndPoint = () => `/s/${getSiteID()}/dw/${API_TYPE}/${API_VERSION}`
+export const getOAuthEndPoint = () => `/dw/oauth2/access_token?client_id=${config.clientId}&grant_type=${GRANT_TYPE}`
 
 export const getRequestHeaders = () => ({
     'Content-Type': 'application/json',
     'x-dw-client-id': config.clientID
+})
+
+export const getAuthHeaders = () => ({
+    'Content-Type': 'application/x-www-form-urlencoded',
+    Authorization: `Basic ${btoa(`${config.businessManagerUser}:${config.businessManagerPassword}:${config.clientPassword}`)}`,
 })
 
 export const getCategoryPath = (id) => `/s/${getSiteID()}/${id}`

--- a/web/app/connectors/_sfcc-connector/config.js
+++ b/web/app/connectors/_sfcc-connector/config.js
@@ -28,7 +28,7 @@ export const getRequestHeaders = () => ({
     'x-dw-client-id': config.clientID
 })
 
-export const getAuthHeaders = () => ({
+export const getDataAuthHeaders = () => ({
     'Content-Type': 'application/x-www-form-urlencoded',
     Authorization: `Basic ${btoa(`${config.businessManagerUser}:${config.businessManagerPassword}:${config.clientPassword}`)}`,
 })

--- a/web/app/connectors/_sfcc-connector/parsers.js
+++ b/web/app/connectors/_sfcc-connector/parsers.js
@@ -125,10 +125,10 @@ export const getInitialSelectedVariant = (variants, initialValues) => {
 export const parseCategories = (categories) => {
     return categories.map((category) => {
         return {
-            title: category.name,
+            title: category.name.default,
             path: getCategoryPath(category.id),
             isCategoryLink: true,
-            children: category.categories ? parseCategories(category.categories) : []
+            children: category.children ? parseCategories(category.children) : []
         }
     })
 }

--- a/web/app/connectors/_sfcc-connector/parsers.js
+++ b/web/app/connectors/_sfcc-connector/parsers.js
@@ -123,7 +123,7 @@ export const getInitialSelectedVariant = (variants, initialValues) => {
 }
 
 export const parseCategories = (categories) => {
-    return categories.map((category) => {
+    return categories.filter((category) => category.c_showInMenu === true).map((category) => {
         return {
             title: category.name.default,
             path: getCategoryPath(category.id),

--- a/web/app/connectors/_sfcc-connector/utils.js
+++ b/web/app/connectors/_sfcc-connector/utils.js
@@ -6,7 +6,7 @@ import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 import {isSessionStorageAvailable} from 'progressive-web-sdk/dist/utils/utils'
 import {getProductById} from 'progressive-web-sdk/dist/store/products/selectors'
 import {getProductHref} from './parsers'
-import {getApiEndPoint, getDataApiEndPoint, getRequestHeaders, getAuthHeaders, getOAuthEndPoint} from './config'
+import {getApiEndPoint, getDataApiEndPoint, getRequestHeaders, getDataAuthHeaders, getOAuthEndPoint} from './config'
 
 const AUTH_KEY_NAME = 'mob-auth'
 const BASKET_KEY_NAME = 'mob-basket'
@@ -216,7 +216,7 @@ export const initSfccDataAuthAndSession = () => {
 
     const options = {
         method: 'POST',
-        headers: getAuthHeaders()
+        headers: getDataAuthHeaders()
     }
 
     let authorization

--- a/web/app/connectors/_sfcc-connector/utils.js
+++ b/web/app/connectors/_sfcc-connector/utils.js
@@ -6,7 +6,7 @@ import {makeRequest} from 'progressive-web-sdk/dist/utils/fetch-utils'
 import {isSessionStorageAvailable} from 'progressive-web-sdk/dist/utils/utils'
 import {getProductById} from 'progressive-web-sdk/dist/store/products/selectors'
 import {getProductHref} from './parsers'
-import {getApiEndPoint, getRequestHeaders, getAuthHeaders, getOAuthEndPoint} from './config'
+import {getApiEndPoint, getDataApiEndPoint, getRequestHeaders, getAuthHeaders, getOAuthEndPoint} from './config'
 
 const AUTH_KEY_NAME = 'mob-auth'
 const BASKET_KEY_NAME = 'mob-basket'
@@ -224,7 +224,7 @@ export const makeDataApiRequest = (path, options) => {
                 ...options,
                 headers
             }
-            return makeRequest(getApiEndPoint() + path, requestOptions)
+            return makeRequest(getDataApiEndPoint() + path, requestOptions)
         })
 }
 

--- a/web/app/connectors/_sfcc-connector/utils.js
+++ b/web/app/connectors/_sfcc-connector/utils.js
@@ -10,6 +10,7 @@ import {getApiEndPoint, getDataApiEndPoint, getRequestHeaders, getAuthHeaders, g
 
 const AUTH_KEY_NAME = 'mob-auth'
 const BASKET_KEY_NAME = 'mob-basket'
+const DATA_AUTH_KEY_NAME = 'mob-data-auth'
 const DATA_TOKEN_EXIRATION_KEY_NAME = 'mob-data-auth-exp'
 
 const setCookieValue = (keyName, value) => {
@@ -59,12 +60,26 @@ export const storeAuthToken = (authorization) => {
     }
 }
 
+export const storeDataAuthToken = (authorization) => {
+    if (authorization) {
+        setItemInBrowserStorage(DATA_AUTH_KEY_NAME, authorization)
+    }
+}
+
 export const getAuthToken = () => {
     return getItemFromBrowserStorage(AUTH_KEY_NAME)
 }
 
+export const getDataAuthToken = () => {
+    return getItemFromBrowserStorage(DATA_AUTH_KEY_NAME)
+}
+
 export const deleteAuthToken = () => {
     removeItemFromBrowserStorage(AUTH_KEY_NAME)
+}
+
+export const deleteDataAuthToken = () => {
+    removeItemFromBrowserStorage(DATA_AUTH_KEY_NAME)
 }
 
 export const deleteBasketID = () => {
@@ -177,7 +192,7 @@ export const initSfccAuthAndSession = () => {
 }
 
 export const initSfccDataAuthAndSession = () => {
-    const authorizationToken = getAuthToken()
+    const authorizationToken = getDataAuthToken()
     const tokenExpiration = getItemFromBrowserStorage(DATA_TOKEN_EXIRATION_KEY_NAME)
 
     if (authorizationToken && tokenExpiration) {
@@ -193,7 +208,7 @@ export const initSfccDataAuthAndSession = () => {
         }
 
         // Clear token and expiry
-        deleteAuthToken()
+        deleteDataAuthToken()
         removeItemFromBrowserStorage(DATA_TOKEN_EXIRATION_KEY_NAME)
 
         return initSfccDataAuthAndSession()
@@ -211,7 +226,7 @@ export const initSfccDataAuthAndSession = () => {
         .then((json) => {
             authorization = json.access_token
             const tokenExpiration = Math.floor(Date.now() / 1000) + json.expires_in
-            storeAuthToken(authorization)
+            storeDataAuthToken(authorization)
             setItemInBrowserStorage(DATA_TOKEN_EXIRATION_KEY_NAME, tokenExpiration)
             return initSfccDataAuthAndSession(authorization)
         })

--- a/web/app/init-sfcc-connector.js
+++ b/web/app/init-sfcc-connector.js
@@ -4,7 +4,11 @@ import {registerConnector} from 'progressive-web-sdk/dist/integration-manager'
 const initConnector = () => {
     registerConnector(Connector({
         siteID: '2017refresh',
-        clientID: '5640cc6b-f5e9-466e-9134-9853e9f9db93'
+        clientID: '5640cc6b-f5e9-466e-9134-9853e9f9db93',
+        dataAPIClientID: 'c191c969-c0e6-4ef3-83e6-879ce82a841c',
+        clientPassword: '#qi$f7%&rtP9HoxhM*YxDj$0SOsRfu',
+        businessManagerUser: 'public-data-api-access',
+        businessManagerPassword: 'ym$1FEAsf2Wc'
     }))
 }
 

--- a/web/app/main.jsx
+++ b/web/app/main.jsx
@@ -26,8 +26,8 @@ import Stylesheet from './stylesheet.scss' // eslint-disable-line no-unused-vars
 
 
 // DO NOT USE! Merlins Connector is an example connector that is for demo only
-import initConnector from './init-merlins-connector'
-// import initConnector from './init-sfcc-connector'
+// import initConnector from './init-merlins-connector'
+import initConnector from './init-sfcc-connector'
 // import initConnector from './init-stub-connector'
 
 initConnector()


### PR DESCRIPTION
Expose SFCC Data API with a public business manager credentials. The `/catalogs/*/categories` endpoint can return a flattened category list array which can be used to initialize navigation.

 **JIRA**: https://mobify.atlassian.net/browse/WEBDATA-184
~~**Linked PRs**: (links to corresponding PRs, optional)~~

## Changes
- Added Data API commands: `fetchNavigationData `, `fetchCategories`,  `initSfccDataAuthAndSession `
- Added Data API utilities: `storeDataAuthToken `, `getDataAuthHeaders `, `getDataAuthToken`, `deleteDataAuthToken`.

## Todos
~~- [ ] (if applicable) analytics events instrumented to measure impact of change~~
- [ ] Add a high-level description of your changes to the CHANGELOG.md, including a link to the PR with your changes

## How to test-drive this PR
- Switch to SFCC connector
- Run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fmobify-tech-prtnr-na03-dw.demandware.net%2Fon%2Fdemandware.store%2FSites-2017refresh-Site%2Fdefault%2FHome-Show&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Verify navigation data is populated with categories in one call.
