### PR TITLE
Update node-sass to v4.5.3

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -3992,6 +3992,16 @@
         "es5-ext": "0.10.24"
       }
     },
+    "es6-templates": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/es6-templates/-/es6-templates-0.2.3.tgz",
+      "integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
+      "dev": true,
+      "requires": {
+        "recast": "0.11.23",
+        "through": "2.3.8"
+      }
+    },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
@@ -6780,6 +6790,32 @@
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
       "dev": true
+    },
+    "html-loader": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/html-loader/-/html-loader-0.4.5.tgz",
+      "integrity": "sha1-X7zYfNY6XEmn/OL+VvQl4Fcpxow=",
+      "dev": true,
+      "requires": {
+        "es6-templates": "0.2.3",
+        "fastparse": "1.1.1",
+        "html-minifier": "3.5.2",
+        "loader-utils": "1.1.0",
+        "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+          "dev": true,
+          "requires": {
+            "big.js": "3.1.3",
+            "emojis-list": "2.1.0",
+            "json5": "0.5.1"
+          }
+        }
+      }
     },
     "html-minifier": {
       "version": "3.5.2",
@@ -10277,9 +10313,9 @@
       }
     },
     "node-sass": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.2.tgz",
-      "integrity": "sha1-QBL6K9EpsdY2URfojZ2gUA2Z2mQ=",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
+      "integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
       "dev": true,
       "requires": {
         "async-foreach": "0.1.3",
@@ -11999,9 +12035,9 @@
       "dev": true
     },
     "progressive-web-sdk": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/progressive-web-sdk/-/progressive-web-sdk-0.18.1.tgz",
-      "integrity": "sha1-3H9WHA3RUayc5w8pdzKe6Bk91E4=",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/progressive-web-sdk/-/progressive-web-sdk-0.19.1.tgz",
+      "integrity": "sha1-VMyjuyuzqAPUoCwkXWqyjTZ5bFo=",
       "dev": true,
       "requires": {
         "archiver": "1.3.0",

--- a/web/package.json
+++ b/web/package.json
@@ -86,7 +86,7 @@
     "mobify-code-style": "2.8.1",
     "nightwatch": "0.9.8",
     "nightwatch-commands": "3.0.0",
-    "node-sass": "4.5.2",
+    "node-sass": "4.5.3",
     "postcss-loader": "1.3.3",
     "progressive-web-sdk": "~0.19.1",
     "prompt": "1.0.0",


### PR DESCRIPTION
Updates `node-sass` to v4.5.3 which adds better support for node 8.

 **JIRA**: *n/a*
 **Linked PRs**: *n/a*

## Changes
- As stated in the description

## Todos
- [ ] ~~(if applicable) analytics events instrumented to measure impact of change~~
- [ ] ~~Add a high-level description of your changes to the CHANGELOG.md, including a link to the PR with your changes~~ (not adding for a patch-level dependency update)

## How to test-drive this PR
- Switch to node 8
- `rm -rf node_modules`
- `npm install`
    - while installing it should _*not*_ compile the sass library but instead download a pre-compiled variant (this is why we're updating this dep)