### PR TITLE
Feature/mbfycnct 51 init product list page pagination, sorting and filters

### DIFF
--- a/web/app/connectors/hybris-connector/categories/commands.js
+++ b/web/app/connectors/hybris-connector/categories/commands.js
@@ -9,7 +9,7 @@ import {receiveProductListProductData} from 'progressive-web-sdk/dist/integratio
 import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
 import {getCategoryEndPoint, getSearchEndPoint} from '../config'
 import {parseProductListData, parseCategoryData} from './parsers'
-import {extractLastPartOfURL, makeApiRequest} from '../utils'
+import {extractLastPartOfURL, getQueryStringValue, makeApiRequest} from '../utils'
 import {PATHS} from '../constants'
 
 const fetchCategoryInfo = (catId) => {
@@ -85,7 +85,9 @@ const getParentCategoryInfo = (catPath) => (dispatch) => {
 export const initProductListPage = (url, routeName) => (dispatch) => {
     let categoryName
     const categoryId = extractLastPartOfURL(url)
-    const searchEndpoint = getSearchEndPoint(categoryId)
+    const pageInQueryString = getQueryStringValue('p')
+    const page = pageInQueryString ? (pageInQueryString - 1) : 0
+    const searchEndpoint = getSearchEndPoint(categoryId, page)
 
     if (categoryId) {
         return fetchCategoryInfo(categoryId)

--- a/web/app/connectors/hybris-connector/categories/commands.js
+++ b/web/app/connectors/hybris-connector/categories/commands.js
@@ -4,11 +4,12 @@
 
 /* eslint-disable no-unused-vars */
 
-import {receiveCategoryContents, receiveCategoryInformation, receiveCategorySortOptions} from 'progressive-web-sdk/dist/integration-manager/categories/results'
+import {receiveCategoryContents, receiveCategoryFilterOptions, receiveCategoryInformation, receiveCategorySortOptions} from 'progressive-web-sdk/dist/integration-manager/categories/results'
 import {receiveProductListProductData} from 'progressive-web-sdk/dist/integration-manager/products/results'
-import {urlToPathKey} from 'progressive-web-sdk/dist/utils/utils'
+import {urlToPathKey, urlToBasicPathKey} from 'progressive-web-sdk/dist/utils/utils'
+import {changeFilterTo} from '../../../store/categories/actions'
 import {getCategoryEndPoint, getSearchEndPoint} from '../config'
-import {parseProductListData, parseCategoryData, parseSortOptions} from './parsers'
+import {parseCategoryData, parseFacets, parseProductListData, parseSortOptions} from './parsers'
 import {extractLastPartOfURL, getQueryStringValue, makeApiRequest} from '../utils'
 import {PATHS} from '../constants'
 
@@ -82,13 +83,14 @@ const getParentCategoryInfo = (catPath) => (dispatch) => {
         })
 }
 
-export const initProductListPage = (url, routeName) => (dispatch) => {
+export const initProductListPage = (url, routeName) => (dispatch, getState) => {
     let categoryName
     const categoryId = extractLastPartOfURL(url)
     const pageInQueryString = getQueryStringValue('p')
     const page = pageInQueryString ? (pageInQueryString - 1) : 0
     const sortOption = getQueryStringValue('sort') || 'relevance'
-    const searchEndpoint = getSearchEndPoint(categoryId, page, sortOption)
+    const appliedFilters = getQueryStringValue('filters')
+    const searchEndpoint = getSearchEndPoint(categoryId, page, sortOption, appliedFilters ? `:${appliedFilters}` : '')
 
     if (categoryId) {
         return fetchCategoryInfo(categoryId)
@@ -106,6 +108,7 @@ export const initProductListPage = (url, routeName) => (dispatch) => {
             })
             .then((responseJSON) => {
                 const pathKey = urlToPathKey(url)
+                const pathKeyWithoutQuery = urlToBasicPathKey(pathKey)
                 const productListData = parseProductListData(responseJSON)
                 const categoryData = parseCategoryData(responseJSON)
                 const parentCategoryPath = getParentCategoryPath(pathKey, categoryId)
@@ -113,9 +116,9 @@ export const initProductListPage = (url, routeName) => (dispatch) => {
                 // Receive page contents
                 dispatch(receiveProductListProductData(productListData))
                 dispatch(receiveCategoryContents(pathKey, categoryData))
-                dispatch(receiveCategoryInformation(pathKey, {
+                dispatch(receiveCategoryInformation(pathKeyWithoutQuery, {
                     id: pathKey,
-                    href: pathKey,
+                    href: pathKeyWithoutQuery,
                     parentId: parentCategoryPath,
                     title: categoryName
                 }))
@@ -126,7 +129,22 @@ export const initProductListPage = (url, routeName) => (dispatch) => {
                 // Receive sorting options
                 const sortOptions = parseSortOptions(responseJSON)
                 if (sortOptions.length > 0) {
-                    dispatch(receiveCategorySortOptions(pathKey, sortOptions))
+                    dispatch(receiveCategorySortOptions(pathKeyWithoutQuery, sortOptions))
+                }
+
+                // Receive filters
+                const currentState = getState()
+                const stateFilterOptions = currentState.categories.toJS().filterOptions
+                const stateCategoryFilterOptions = stateFilterOptions ? stateFilterOptions[pathKeyWithoutQuery] : null
+
+                if (!stateCategoryFilterOptions) {
+                    const filterOptions = parseFacets(responseJSON, appliedFilters)
+                    if (filterOptions.length > 0) {
+                        dispatch(receiveCategoryFilterOptions(pathKeyWithoutQuery, filterOptions))
+                    }
+                }
+                if (appliedFilters) {
+                    dispatch(changeFilterTo(appliedFilters))
                 }
             })
     }

--- a/web/app/connectors/hybris-connector/categories/parsers.js
+++ b/web/app/connectors/hybris-connector/categories/parsers.js
@@ -35,3 +35,29 @@ export const parseSortOptions = ({sorts = []}) => {
         label: name
     }))
 }
+
+export const parseFacets = ({facets = []}, appliedFilters) => {
+    return facets.map(({name, values}) => {
+        const ruleset = name.toLowerCase()
+        const kinds = values.map(({count, name, query, selected}) => {
+            let filterQuery = ''
+            const queryValues = query.query.value.split(':')
+            const queryValuesLength = queryValues.length
+            if (queryValuesLength) {
+                filterQuery = encodeURIComponent(`${queryValues[queryValuesLength - 2]}:${queryValues[queryValuesLength - 1]}`)
+            }
+            return {
+                count,
+                label: name,
+                query: !selected ? filterQuery : appliedFilters,
+                searchKey: !selected ? filterQuery : appliedFilters,
+                ruleset,
+            }
+        })
+        return {
+            label: name,
+            ruleset,
+            kinds
+        }
+    })
+}

--- a/web/app/connectors/hybris-connector/categories/parsers.js
+++ b/web/app/connectors/hybris-connector/categories/parsers.js
@@ -28,3 +28,10 @@ export const parseCategoryData = ({pagination, products = []}) => {
     }
     return categoryData
 }
+
+export const parseSortOptions = ({sorts = []}) => {
+    return sorts.map(({code, name}) => ({
+        id: code,
+        label: name
+    }))
+}

--- a/web/app/connectors/hybris-connector/config.js
+++ b/web/app/connectors/hybris-connector/config.js
@@ -2,6 +2,7 @@
 /* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 import {PATHS} from './constants'
+import {ITEMS_PER_PAGE} from '../../containers/product-list/constants'
 
 const API_HOST = 'https://hydemo-electronics.thinkwrap.com'
 const API_TYPE = 'rest'
@@ -23,7 +24,7 @@ export const getAuthEndPoint = () => `${API_HOST}/authorizationserver/oauth/toke
 
 export const getProductEndPoint = (productId) => `/products/${productId}?fields=FULL`
 export const getCategoryEndPoint = (catId) => `/catalogs/${getCatalogId()}/${getCatalogVersionId()}/categories/${catId}`
-export const getSearchEndPoint = (catId) => `/products/search/?pageSize=5&currentPage=0&fields=FULL&query=:relevance:allCategories:${catId}`
+export const getSearchEndPoint = (catId, page) => `/products/search/?pageSize=${ITEMS_PER_PAGE}&currentPage=${page}&fields=FULL&query=:relevance:allCategories:${catId}`
 
 export const getImageType = (type) => config.imagesTypes[type]
 export const getImageSize = (size) => config.imagesSizes[size]

--- a/web/app/connectors/hybris-connector/config.js
+++ b/web/app/connectors/hybris-connector/config.js
@@ -24,7 +24,8 @@ export const getAuthEndPoint = () => `${API_HOST}/authorizationserver/oauth/toke
 
 export const getProductEndPoint = (productId) => `/products/${productId}?fields=FULL`
 export const getCategoryEndPoint = (catId) => `/catalogs/${getCatalogId()}/${getCatalogVersionId()}/categories/${catId}`
-export const getSearchEndPoint = (catId, page, sort) => `/products/search/?pageSize=${ITEMS_PER_PAGE}&currentPage=${page}&fields=FULL&query=:${sort}:allCategories:${catId}`
+export const getSearchEndPoint = (catId, page, sort, filters) =>
+    `/products/search/?pageSize=${ITEMS_PER_PAGE}&currentPage=${page}&fields=FULL&query=:${sort}:allCategories:${catId}${filters}`
 
 export const getImageType = (type) => config.imagesTypes[type]
 export const getImageSize = (size) => config.imagesSizes[size]

--- a/web/app/connectors/hybris-connector/config.js
+++ b/web/app/connectors/hybris-connector/config.js
@@ -24,7 +24,7 @@ export const getAuthEndPoint = () => `${API_HOST}/authorizationserver/oauth/toke
 
 export const getProductEndPoint = (productId) => `/products/${productId}?fields=FULL`
 export const getCategoryEndPoint = (catId) => `/catalogs/${getCatalogId()}/${getCatalogVersionId()}/categories/${catId}`
-export const getSearchEndPoint = (catId, page) => `/products/search/?pageSize=${ITEMS_PER_PAGE}&currentPage=${page}&fields=FULL&query=:relevance:allCategories:${catId}`
+export const getSearchEndPoint = (catId, page, sort) => `/products/search/?pageSize=${ITEMS_PER_PAGE}&currentPage=${page}&fields=FULL&query=:${sort}:allCategories:${catId}`
 
 export const getImageType = (type) => config.imagesTypes[type]
 export const getImageSize = (size) => config.imagesSizes[size]

--- a/web/app/connectors/hybris-connector/utils.js
+++ b/web/app/connectors/hybris-connector/utils.js
@@ -224,6 +224,19 @@ export const extractLastPartOfURL = (url) => {
     if (!url) {
         return ''
     }
+
     const splitURL = url.split('/')
-    return splitURL[splitURL.length - 1]
+    const lastPartUrl = splitURL[splitURL.length - 1]
+    const queryStringIndex = lastPartUrl.indexOf('?')
+
+    // Check if there is a query string in URL
+    if (queryStringIndex === -1) {
+        return lastPartUrl
+    } else {
+        return lastPartUrl.substring(0, queryStringIndex)
+    }
 }
+
+
+export const getQueryStringValue = (key) =>
+    decodeURIComponent(window.location.search.replace(new RegExp('^(?:.*[&\\?]' + encodeURIComponent(key).replace(/[\.\+\*]/g, '\\$&') + '(?:\\=([^&]*))?)?.*$', 'i'), '$1'))


### PR DESCRIPTION
This PR covers pagination, sorting and filtering functionality in the initProductListPage command.

 **JIRA**: ([MBFYCNCT-51](https://thinkwrap.jira.com/browse/MBFYCNCT-51))

## Changes
-  Added pagination
-  Added sorting options
-  Added filters
-  Added parseFacets to categories/parsers.js

## Todos
- [ ] Page number no reset to 1 when filter applied. To be handled in UI

## How to test-drive this PR
- Run `npm run dev`
- Preview [Thinkwrap accelerator](https://preview.mobify.com/?url=https%3A%2F%2Fhydemo-electronics.thinkwrap.com%2Fyacceleratorstorefront%2Felectronics%2Fen%2F%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Navigate to a category using the main navigation menu (e.g. Clothes > T-shirts > T-shirts your
- play around with pagination, sort options and filters. 