### PR TITLE
Update the order status for SFCC to match desktop

### DIFF
--- a/web/app/utils/utils.js
+++ b/web/app/utils/utils.js
@@ -182,3 +182,6 @@ export const validateCCNumber = (ccNumber) => {
 
     return checkSum !== 0 && (checkSum % 10) === 0
 }
+// Converts a string into title case
+// https://stackoverflow.com/questions/196972/convert-string-to-title-case-with-javascript
+export const stringToTitleCase = (str) => str.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase())


### PR DESCRIPTION
This PR updates the order status displayed for SFCC to match desktop. 


 **JIRA**: https://mobify.atlassian.net/browse/WEB-1433 & https://mobify.atlassian.net/browse/WEB-1434
 **Linked PRs**: n/a

## Changes
- Add util to convert string to title case
- Add function to determine order status based on SFCC order object
- Use util in`parseOrder` and `parseOrdersResponse`

## Todos
- [ ] (if applicable) analytics events instrumented to measure impact of change
- [ ] Add a high-level description of your changes to the CHANGELOG.md, including a link to the PR with your changes

## How to test-drive this PR
- Switch to the SFCC connector
- Run `npm start`
- Preview the SFCC site
- log in to an account that has orders
- view the orders list page and the order details page
- the status listed on each page should match the status shown on desktop