### PR TITLE
Resolve modal issues on Wishlist page

### DIFF
--- a/web/app/connectors/_merlins-connector/products/commands.js
+++ b/web/app/connectors/_merlins-connector/products/commands.js
@@ -34,7 +34,7 @@ export const initProductDetailsPage = (url) => (dispatch) => {
             dispatch(receiveProductDetailsProductData({[id]: productDetailsData}))
             dispatch(receiveFormInfo({[id]: pdpAddToCartFormParser($, $response)}))
 
-            if (url.includes('wishlist/index/configure')) {
+            if (url.includes('wishlist/index/configure') && productDetailsData.variants.length) {
                 dispatch(addNotification(
                     'configureProfuct',
                     'You need to choose options for your item.',

--- a/web/app/styles/_modals.scss
+++ b/web/app/styles/_modals.scss
@@ -5,5 +5,6 @@
 @import '../modals/cart-wishlist/cart-wishlist';
 @import '../modals/mini-cart/mini-cart';
 @import '../modals/product-details-item-added/product-details-item-added';
+@import '../modals/wishlist-item-added/wishlist-item-added';
 @import '../modals/product-list-filter/product-list-filter';
 @import '../modals/navigation/navigation';


### PR DESCRIPTION
# Resolve modal issues on Wishlist page

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1425
 **Linked PRs**: https://github.com/mobify/platform-scaffold/pull/934

## Changes
- Fix modal styling when adding to cart from wishlist
- Only show "You need to select product options" if product options exist

## Todos
- [ ] (if applicable) analytics events instrumented to measure impact of change
- [ ] Add a high-level description of your changes to the CHANGELOG.md, including a link to the PR with your changes

## How to test-drive this PR
- Run `npm start`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Test editing wishlist items, ensuring "You must select product options" only shows up on Eye of Newt
 - Test adding to cart from wishlist on Magento connector, ensuring that the modal is properly anchored to the bottom of the screen