### PR TITLE
Hotfix for v8.1 tag updates

### DIFF
--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -1,5 +1,5 @@
 /* global NATIVE_WEBPACK_ASTRO_VERSION, MESSAGING_SITE_ID, MESSAGING_ENABLED, DEBUG */
-import {getAssetUrl, getBuildOrigin, loadAsset, initCacheManifest} from 'progressive-web-sdk/dist/asset-utils'
+import {getAssetUrl, getBuildOrigin, loadAsset, initCacheManifest, isV8Tag} from 'progressive-web-sdk/dist/asset-utils'
 import {isSamsungBrowser, isFirefoxBrowser, isLocalStorageAvailable} from 'progressive-web-sdk/dist/utils/utils'
 import {displayPreloader} from 'progressive-web-sdk/dist/preloader'
 import cacheHashManifest from '../tmp/loader-cache-hash-manifest.json'
@@ -168,6 +168,8 @@ const attemptToInitializeApp = () => {
     const CAPTURING_CDN = '//cdn.mobify.com/capturejs/capture-latest.min.js'
     const ASTRO_CLIENT_CDN = `//assets.mobify.com/astro/astro-client-${ASTRO_VERSION}.min.js`
 
+    const IS_V8_TAG = isV8Tag() // TODO: Remove this! Hotfix for V8 tag to be removed during next release
+
     window.Progressive = {
         AstroPromise: Promise.resolve({}),
         Messaging: {
@@ -182,7 +184,14 @@ const attemptToInitializeApp = () => {
             displayPreloader(preloadCSS, preloadHTML, preloadJS)
         }
 
-        document.write('<body>')
+        // TODO: Remove this! Hotfix for V8 tag to be removed during next release
+        //
+        // We are typically loaded synchronously - so we end up in <head>, and
+        // therefore <body> does not exist yet. Write it out first, so we can
+        // add elements to it after this point
+        if (IS_V8_TAG && document.getElementsByTagName('body').length === 0) {
+            document.write('<body>')
+        }
 
         // Create React mounting target
         const body = document.getElementsByTagName('body')[0]
@@ -291,14 +300,15 @@ const attemptToInitializeApp = () => {
         // time to interactive from being delayed.
         prefetchLink({href: '//www.google-analytics.com/analytics.js'})
 
-        if (document.querySelectorAll('plaintext').length > 0) {
+        // TODO: Remove this! Hotfix for V8 tag to be removed during next release
+        if (IS_V8_TAG && document.querySelectorAll('plaintext').length <= 0) {
             // If the plaintext tag is already present in the page, this means that
             // the desktop site has already been prevented from rendering. This
             // is due to the use of an older Mobify tag (pre V8), which inserts
             // the plaintext tag inline.
-            return
+            document.write('<plaintext style="display: none;">')
         }
-        document.write('<plaintext style="display: none;">')
+
     } else {
         const capturing = document.createElement('script')
         capturing.async = true

--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -182,6 +182,8 @@ const attemptToInitializeApp = () => {
             displayPreloader(preloadCSS, preloadHTML, preloadJS)
         }
 
+        document.write('<body>')
+
         // Create React mounting target
         const body = document.getElementsByTagName('body')[0]
         const reactTarget = document.createElement('div')
@@ -288,6 +290,15 @@ const attemptToInitializeApp = () => {
         // and thus we want to fetch it so execution is not delayed to prevent
         // time to interactive from being delayed.
         prefetchLink({href: '//www.google-analytics.com/analytics.js'})
+
+        if (document.querySelectorAll('plaintext').length > 0) {
+            // If the plaintext tag is already present in the page, this means that
+            // the desktop site has already been prevented from rendering. This
+            // is due to the use of an older Mobify tag (pre V8), which inserts
+            // the plaintext tag inline.
+            return
+        }
+        document.write('<plaintext style="display: none;">')
     } else {
         const capturing = document.createElement('script')
         capturing.async = true

--- a/web/package.json
+++ b/web/package.json
@@ -82,7 +82,7 @@
     "nightwatch-commands": "2.1.0",
     "node-sass": "4.5.2",
     "postcss-loader": "1.3.3",
-    "progressive-web-sdk": "~0.17.0",
+    "progressive-web-sdk": "0.17.4",
     "prompt": "1.0.0",
     "raw-loader": "0.5.1",
     "react-addons-test-utils": "15.4.2",


### PR DESCRIPTION
The v8.1 tag, when previewing, will use the currently published bundle version of `loader.js`. That version of `loader.js` will then (when previewing) load the localhost version of `loader.js`. This means that you need both the published version and your local version to be aware of the v8.1 tag.

Merlin's published bundle is aware, but `master` branch is not. This means that newly generated projects using the scaffold (i.e. based on `master` branch) will fail when previewing the site.

**NOTE**: These changes should be ignored when merging `develop`! They are an attempt at a hotfix only.

**JIRA**: https://mobify.atlassian.net/browse/WEB-1513
**Linked PRs**: https://github.com/mobify/progressive-web-sdk/pull/827

## Changes
- Inject a `<body>` tag before referencing it when attempting to create React mounting point
- Inject `<plaintext>` at the same rough point that the `develop` branch version of `loader.js` does (since the v8.1 tag does not do this for you)

## Todos
- [x] Use 0.17.4 of `progressive-web-sdk`
- [x] Safer approach to `<body>` injection
- [x] Wait for npm release of `progressive-web-sdk@0.17.4`
- [ ] +1

## How to test-drive this PR
- (necessary config changes)
- Run `npm start`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- (how to access the new / changed functionality -- fixtures, URLs)
