### PR TITLE
WEB-1512: fix phone number detection

### DIFF
--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -452,6 +452,11 @@ const loadPWA = () => {
     initCacheManifest(cacheHashManifest)
     triggerAppStartEvent(true)
 
+    loadAsset('meta', {
+        name: 'format-detection',
+        content: 'telephone=no'
+    })
+
     /* eslint-disable max-len */
     loadAsset('meta', {
         name: 'viewport',


### PR DESCRIPTION
This PR prevents iOS from auto formatting phone numbers. 

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1512
 **Linked PRs**: n/a

## Changes
- Add meta tag to prevent format detection
- Update order details parser to handle possible <a> wrapped around address phone numbers

## Todos
- [ ] (if applicable) analytics events instrumented to measure impact of change
- [ ] Add a high-level description of your changes to the CHANGELOG.md, including a link to the PR with your changes

## How to test-drive this PR
- Run `npm start`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1) using the iOS simulator 
- sign in to an account with orders placed
- navigate to a view order page
- phone numbers should appear without <a> tags wrapped around them