### PR TITLE
Generating unique string IDs for SFCC adding address

### DIFF
--- a/web/app/containers/account-address/actions.js
+++ b/web/app/containers/account-address/actions.js
@@ -11,7 +11,7 @@ import {UI_NAME} from 'progressive-web-sdk/dist/analytics/data-objects/'
 export const setAddressID = createAction('Set Address ID', ['addressID'])
 export const setIsEditing = createAction('Set isEdit', ['isEdit'])
 
-export const submitAddAddress = (formValues) => (dispatch, getState) => {
+export const submitAddAddress = (formValues) => (dispatch) => {
     const {firstname, lastname} = splitFullName(formValues.name)
     // Merlin's connector doens't support address names,
     // and SFCC requires an address name.

--- a/web/app/containers/account-address/actions.js
+++ b/web/app/containers/account-address/actions.js
@@ -3,7 +3,6 @@
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 
 import {createAction} from 'progressive-web-sdk/dist/utils/action-creation'
-import Immutable from 'immutable'
 import {closeModal} from 'progressive-web-sdk/dist/store/modals/actions'
 import {splitFullName} from '../../utils/utils'
 import {addAddress, deleteAddress, editAddress} from 'progressive-web-sdk/dist/integration-manager/account/commands'
@@ -34,33 +33,4 @@ export const submitEditAddress = (formValues) => (dispatch) => {
 
 export const removeAddress = (id) => (dispatch) => {
     return dispatch(deleteAddress(id))
-}
-
-
-
-
-
-
-
-
-
-// currently unused, collision check example
-const checkForAddressIDCollisions = (addresses) => {
-    let idSet = Immutable.Set()
-    let addressId = Math
-        .random()
-        .toString(36)
-        .slice(2)
-    addresses.forEach(({id}) => {
-        idSet = idSet.add(id)
-    })
-
-    while (idSet.has(addressId)) {
-        addressId = Math
-            .random()
-            .toString(36)
-            .slice(2)
-    }
-
-    return addressId
 }

--- a/web/app/containers/account-address/actions.js
+++ b/web/app/containers/account-address/actions.js
@@ -12,27 +12,6 @@ import {UI_NAME} from 'progressive-web-sdk/dist/analytics/data-objects/'
 export const setAddressID = createAction('Set Address ID', ['addressID'])
 export const setIsEditing = createAction('Set isEdit', ['isEdit'])
 
-// currently unused, checks set if address Id exists
-const assignAddressName = (addresses) => {
-    let idSet = Immutable.Set()
-    let addressId = Math
-        .random()
-        .toString(36)
-        .slice(2)
-    addresses.forEach(({id}) => {
-        idSet = idSet.add(id)
-    })
-
-    while (idSet.has(addressId)) {
-        addressId = Math
-            .random()
-            .toString(36)
-            .slice(2)
-    }
-
-    return addressId
-}
-
 export const submitAddAddress = (formValues) => (dispatch, getState) => {
     const {firstname, lastname} = splitFullName(formValues.name)
     // Merlin's connector doens't support address names,
@@ -55,4 +34,33 @@ export const submitEditAddress = (formValues) => (dispatch) => {
 
 export const removeAddress = (id) => (dispatch) => {
     return dispatch(deleteAddress(id))
+}
+
+
+
+
+
+
+
+
+
+// currently unused, collision check example
+const checkForAddressIDCollisions = (addresses) => {
+    let idSet = Immutable.Set()
+    let addressId = Math
+        .random()
+        .toString(36)
+        .slice(2)
+    addresses.forEach(({id}) => {
+        idSet = idSet.add(id)
+    })
+
+    while (idSet.has(addressId)) {
+        addressId = Math
+            .random()
+            .toString(36)
+            .slice(2)
+    }
+
+    return addressId
 }

--- a/web/app/containers/account-address/partials/account-address-fields.jsx
+++ b/web/app/containers/account-address/partials/account-address-fields.jsx
@@ -26,16 +26,6 @@ const AccountAddressFields = ({
             <FieldRow>
                 <ReduxForm.Field
                     component={Field}
-                    name="addressName"
-                    label="Address Name"
-                >
-                    <input type="text" noValidate data-analytics-name={UI_NAME.addressName} />
-                </ReduxForm.Field>
-            </FieldRow>
-
-            <FieldRow>
-                <ReduxForm.Field
-                    component={Field}
                     name="name"
                     label="First & Last Name"
                 >


### PR DESCRIPTION
# Generating unique string IDs for SFCC adding address

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1511

## Changes
- Merlin's connector does not support "address names"
- For this reason, the form field was taken out of the UI
- Since the SFCC connector requires an address name, our UI is now generating an ID which it passes to the connector

## Todos
- [ ] (if applicable) analytics events instrumented to measure impact of change
- [ ] Add a high-level description of your changes to the CHANGELOG.md, including a link to the PR with your changes

## How to test-drive this PR
- Try SFCC & Merlin's connectors
- Run `npm start`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Login to mobifyqa@gmail.com
- Navigate to the account address page
- Attempt to add addresses on both connectors