### PR TITLE
Catch error from trackTTI

### DIFF
--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -95,7 +95,15 @@ if ('PerformanceObserver' in window) {
             }
         }
     })
-    paintObserver.observe({entryTypes: ['paint']})
+    try {
+        paintObserver.observe({entryTypes: ['paint']})
+    } catch (e) {
+        // If the `entryTypes` doesn't contain any supported entries (e.g. Safari 11)
+        // https://w3c.github.io/performance-timeline/#dom-performanceobserver-observe()
+        if (e.name !== 'TypeError') {
+            throw e
+        }
+    }
 }
 
 const trackTTI = () => {
@@ -425,7 +433,13 @@ const waitForBody = () => {
  * loaded.
  */
 const loadPWA = () => {
-    trackTTI()
+    try {
+        trackTTI()
+    } catch (e) {
+        if (typeof console !== 'undefined') {
+            console.error(e.message)
+        }
+    }
     // We need to check if loadScriptsSynchronously is undefined because if it's
     // previously been set to false, we want it to remain set to false.
     if (window.loadScriptsSynchronously === undefined) {


### PR DESCRIPTION
If the `entryTypes` doesn't contain any supported entries (e.g. Safari 11)
https://w3c.github.io/performance-timeline/#dom-performanceobserver-observe()

![image](https://user-images.githubusercontent.com/1215939/29632400-bf9e5c8c-87f7-11e7-85d4-9a53f3210030.png)


**Related PR**: https://github.com/mobify/lancome/pull/312
**JIRA**: https://mobify.atlassian.net/browse/WEBDATA-242

## Changes
- [x] Catch performance related error on Safari


## How to test-drive this PR

- Run `npm start`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- Should not see error in Safari <= 11
