### PR TITLE
Disable non-pwa feature

### DIFF
--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -1,4 +1,4 @@
-/* global AJS_SLUG, NATIVE_WEBPACK_ASTRO_VERSION, MESSAGING_SITE_ID, SITE_NAME, MESSAGING_ENABLED, DEBUG */
+/* global AJS_SLUG, NATIVE_WEBPACK_ASTRO_VERSION, MESSAGING_SITE_ID, SITE_NAME, MESSAGING_ENABLED, DEBUG, NON_PWA_ENABLED */
 import {getAssetUrl, getBuildOrigin, loadAsset, initCacheManifest} from 'progressive-web-sdk/dist/asset-utils'
 import {
     documentWriteSupported,
@@ -30,6 +30,7 @@ import preloadJS from 'raw-loader!./preloader/preload.js' // eslint-disable-line
 
 const ASTRO_VERSION = NATIVE_WEBPACK_ASTRO_VERSION // replaced at build time
 const messagingEnabled = MESSAGING_ENABLED  // replaced at build time
+const nonPwaEnabled = NON_PWA_ENABLED // replaced at build time
 
 const CAPTURING_CDN = '//cdn.mobify.com/capturejs/capture-latest.min.js'
 const ASTRO_CLIENT_CDN = `//assets.mobify.com/astro/astro-client-${ASTRO_VERSION}.min.js`
@@ -643,7 +644,7 @@ if (shouldPreview()) {
     ) {
         loaderLog('Starting in PWA mode')
         loadPWA()
-    } else if (isSupportedNonPWABrowser()) {
+    } else if (NON_PWA_ENABLED && isSupportedNonPWABrowser()) {
         // In preview mode, we arrive here when IS_PREVIEW_PWA_MODE is
         // false - the default for preview is to load the PWA, not non-PWA
         // mode.

--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -1,4 +1,4 @@
-/* global AJS_SLUG, NATIVE_WEBPACK_ASTRO_VERSION, MESSAGING_SITE_ID, SITE_NAME, MESSAGING_ENABLED, DEBUG, NON_PWA_ENABLED */
+/* global AJS_SLUG, NATIVE_WEBPACK_ASTRO_VERSION, MESSAGING_SITE_ID, SITE_NAME, MESSAGING_ENABLED, DEBUG, WEBPACK_NON_PWA_ENABLED */
 import {getAssetUrl, getBuildOrigin, loadAsset, initCacheManifest} from 'progressive-web-sdk/dist/asset-utils'
 import {
     documentWriteSupported,
@@ -30,7 +30,7 @@ import preloadJS from 'raw-loader!./preloader/preload.js' // eslint-disable-line
 
 const ASTRO_VERSION = NATIVE_WEBPACK_ASTRO_VERSION // replaced at build time
 const messagingEnabled = MESSAGING_ENABLED  // replaced at build time
-const nonPwaEnabled = NON_PWA_ENABLED // replaced at build time
+const nonPwaEnabled = WEBPACK_NON_PWA_ENABLED // replaced at build time
 
 const CAPTURING_CDN = '//cdn.mobify.com/capturejs/capture-latest.min.js'
 const ASTRO_CLIENT_CDN = `//assets.mobify.com/astro/astro-client-${ASTRO_VERSION}.min.js`

--- a/web/app/loader.js
+++ b/web/app/loader.js
@@ -644,7 +644,7 @@ if (shouldPreview()) {
     ) {
         loaderLog('Starting in PWA mode')
         loadPWA()
-    } else if (NON_PWA_ENABLED && isSupportedNonPWABrowser()) {
+    } else if (nonPwaEnabled && isSupportedNonPWABrowser()) {
         // In preview mode, we arrive here when IS_PREVIEW_PWA_MODE is
         // false - the default for preview is to load the PWA, not non-PWA
         // mode.

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,7 @@
   "mobifyGAID": "UA-78284797-2",
   "messagingSiteId": "merlinspotions",
   "messagingEnabled": true,
-  "nonPwaEnabled": true,
+  "nonPwaEnabled": false,
   "repository": {
     "type": "git",
     "url": "http://github.com/mobify/platform-scaffold"

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
   "mobifyGAID": "UA-78284797-2",
   "messagingSiteId": "merlinspotions",
   "messagingEnabled": true,
+  "nonPwaEnabled": true,
   "repository": {
     "type": "git",
     "url": "http://github.com/mobify/platform-scaffold"

--- a/web/webpack/base.loader.js
+++ b/web/webpack/base.loader.js
@@ -61,8 +61,9 @@ module.exports = {
             }
         }),
         new webpack.DefinePlugin({
-            // This is defined as a boolean, not a string
+            // These are defined as a boolean, not a string
             MESSAGING_ENABLED: `${webPackageJson.messagingEnabled}`,
+            NON_PWA_ENABLED: `${webPackageJson.nonPwaEnabled}`,
             // These are defined as string constants
             MESSAGING_SITE_ID: `'${webPackageJson.messagingSiteId}'`,
             NATIVE_WEBPACK_ASTRO_VERSION: readNativeAstroVersion(),

--- a/web/webpack/base.loader.js
+++ b/web/webpack/base.loader.js
@@ -63,7 +63,7 @@ module.exports = {
         new webpack.DefinePlugin({
             // These are defined as a boolean, not a string
             MESSAGING_ENABLED: `${webPackageJson.messagingEnabled}`,
-            NON_PWA_ENABLED: `${webPackageJson.nonPwaEnabled}`,
+            WEBPACK_NON_PWA_ENABLED: `${webPackageJson.nonPwaEnabled}`,
             // These are defined as string constants
             MESSAGING_SITE_ID: `'${webPackageJson.messagingSiteId}'`,
             NATIVE_WEBPACK_ASTRO_VERSION: readNativeAstroVersion(),


### PR DESCRIPTION
We don't yet want to release the non-pwa feature until the September release. Add a package.json controlled flag (injected at build-time via webpack), and use that flag in loader.js to disable it.

## Changes
- Add `nonPwaEnabled` boolean to `web/package.json`, with value `false`
- Update the webpack `base.loader.js` config to add a `NON_PWA_ENABLED` value at build-time
- Update `web/app/loader.js` with a local variable named `nonPwaEnabled`
- Use the local `nonPwaEnabled` variable to guard against the entire NonPwa code branch

## Todos
- [x] +1

## How to test-drive this PR
- Run `npm start`
- Using Charles, Map Remote `https://cdn.mobify.com/sites/progressive-web-scaffold/production/loader.js` to `https://localhost:8443/loader.js`
- View the desktop site without preview (and without mobile emulation)
- There should be no network requests for a `non-pwa.js` file, and you should see `a.js` requested by the loader.js file
