### PR TITLE
WEB-1498: Use browser history goBack and goForward functions A2HS

### DIFF
--- a/web/app/containers/header/actions.js
+++ b/web/app/containers/header/actions.js
@@ -6,7 +6,6 @@
 import {createAction, createActionWithAnalytics} from 'progressive-web-sdk/dist/utils/action-creation'
 import {getSearchSuggestions, searchProducts} from 'progressive-web-sdk/dist/integration-manager/app/commands'
 import {EVENT_ACTION} from 'progressive-web-sdk/dist/analytics/data-objects/'
-import {extractPathFromURL} from 'progressive-web-sdk/dist/utils/utils'
 import {browserHistory} from 'progressive-web-sdk/dist/routing'
 
 export const pushHistoryItem = createAction('Added item to history stack')
@@ -36,11 +35,8 @@ export const searchSubmit = (query) => (dispatch) => {
     dispatch(searchProducts(query))
 }
 
-export const goBack = () => (dispatch, getState) => {
+export const goBack = () => (dispatch) => {
     dispatch(popHistoryItem())
     dispatch(setIsHistoryPage(true))
-    const {ui: {header}} = getState()
-    const history = header.get('appHistory')
-    const pathname = extractPathFromURL(history.last())
-    return browserHistory.push({pathname})
+    return browserHistory.goBack()
 }

--- a/web/app/modals/more-menu/container.jsx
+++ b/web/app/modals/more-menu/container.jsx
@@ -9,6 +9,7 @@ import {createPropsSelector} from 'reselect-immutable-helpers'
 import {MORE_MENU} from '../constants'
 import {closeModal, openModal} from 'progressive-web-sdk/dist/store/modals/actions'
 import {isModalOpen} from 'progressive-web-sdk/dist/store/modals/selectors'
+import {browserHistory} from 'progressive-web-sdk/dist/routing'
 
 import Button from 'progressive-web-sdk/dist/components/button'
 import Divider from 'progressive-web-sdk/dist/components/divider'
@@ -79,7 +80,7 @@ class MoreMenuModal extends React.Component {
                                 className="u-width-block-full"
                                 innerClassName={linkClasses}
                                 text="Forward"
-                                onClick={() => { window.history.forward() }}
+                                onClick={() => { browserHistory.goForward() }}
                                 data-analytics-name={UI_NAME.browserForward}
                             />
 


### PR DESCRIPTION
This PR updates the forward and back buttons in the A2HS header so they use the browserHistory object to go back & forward through the app. Previously the two buttons handled this behaviour inconsistently (one through window.history one through browserHistory.push) this meant there was never a forward state if you used the back button in the header.

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1498
 **Linked PRs**: n/a

## Changes
- Use `browserHistory.goForward()` for forward button in the A2HS more menu
- Use `browserHistory.goBack` for back button in A2HS header bar
- Remove code that pulls back URL off the state

## Todos
- [ ] (if applicable) analytics events instrumented to measure impact of change
- [ ] Add a high-level description of your changes to the CHANGELOG.md, including a link to the PR with your changes

## How to test-drive this PR
- checkout the `develop` branch of the SDK
- cd into the SDK folder
- run `npm link`
- cd into the scaffold folder
- run `npm link progressive-web-sdk`
- run `npm run dev`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- browse to https://www.merlinspotions.com/?homescreen=1
- navigate to a new page in the app
- hit the back button in the header bar (next to the MP logo)
- open the more menu
- click forward
- you should be taken to the second page you viewed in the app

