### PR TITLE
WEB-1493: Store form key cookie on app initialization

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Update header bar when displaying in Add to homescreen mode [#983](https://github.com/mobify/platform-scaffold/pull/983)
 - Add Share to PDP [#963](https://github.com/mobify/platform-scaffold/pull/963)
 - Fix account dashboard path [#986](https://github.com/mobify/platform-scaffold/pull/986)
+- Fix bug with account login/logout for Merlin's connector [#992](https://github.com/mobify/platform-scaffold/pull/992)
 
 ## 0.20.0 (August 24, 2017)
 - Add "View Orders" list to My Account [#912](https://github.com/mobify/platform-scaffold/pull/912)

--- a/web/app/connectors/_merlins-connector/app/commands.js
+++ b/web/app/connectors/_merlins-connector/app/commands.js
@@ -97,6 +97,8 @@ export const searchProducts = (query) => (dispatch) => {
 export const initApp = () => (dispatch) => {
     // Use the pre-existing form_key if it already exists
     const formKey = getCookieValue('form_key') || generateFormKeyCookie()
+    // Make sure the form key is stored in a cookie
+    document.cookie = `form_key=${formKey};`
     dispatch(receiveFormKey(formKey))
 
     dispatch(setAccountAddressURL(ACCOUNT_ADDRESS_URL))


### PR DESCRIPTION
This PR resolves a bug where a user is unable to log back in after logging out of their account. 

 **JIRA**: https://mobify.atlassian.net/browse/WEB-1493
 **Linked PRs**: n/a

## Changes
- Store form_key in a cookie so it gets sent with all requests

## Todos
- [ ] (if applicable) analytics events instrumented to measure impact of change
- [ ] Add a high-level description of your changes to the CHANGELOG.md, including a link to the PR with your changes

## How to test-drive this PR
- Run `npm start`
- Preview [Merlin's Potions](https://preview.mobify.com/?url=https%3A%2F%2Fwww.merlinspotions.com%2F&site_folder=https%3A%2F%2Flocalhost%3A8443%2Floader.js&disabled=0&domain=&scope=1)
- log into an account
- open the menu and click sign out
- open the menu and click sign in
- log back into your account
- you should be able to log in again
