### PR TITLE
Add better Debugging for End to End Tests.

### DIFF
--- a/web/CHANGELOG.md
+++ b/web/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## To be released
+- Update E2E Tests to have debug flag [#1002](https://github.com/mobify/platform-scaffold/pull/1002)
+- Add Circle2.0 config and DockerFile [#983](https://github.com/mobify/platform-scaffold/pull/881)
 - Update header bar when displaying in Add to homescreen mode [#983](https://github.com/mobify/platform-scaffold/pull/983)
 - Add Share to PDP [#963](https://github.com/mobify/platform-scaffold/pull/963)
 - Fix account dashboard path [#986](https://github.com/mobify/platform-scaffold/pull/986)

--- a/web/README.md
+++ b/web/README.md
@@ -16,7 +16,7 @@ npm run
 
 ```
 npm install
-npm start
+npm run dev
 ```
 
 ## Deploying Bundle to Mobify Cloud
@@ -224,7 +224,7 @@ Then verify that the minified contents of the build directory are less than a sp
   }
 ```
 
-Run this command:
+Run this command: 
 
 ```
 npm run test:max-file-size

--- a/web/README.md
+++ b/web/README.md
@@ -16,7 +16,7 @@ npm run
 
 ```
 npm install
-npm run dev
+npm start
 ```
 
 ## Deploying Bundle to Mobify Cloud
@@ -182,14 +182,29 @@ npm run test:watch
 
 To verify that changes do not break the guest and registered checkout flows:
 
+First have `npm start` running in another tab
+```
+npm run test:e2e
+```
+
+To run only one test:
+```
+npm run test:e2e --test tests/e2e/workflows/home.js
+```
+
+To run both starting the server and e2e:
 ```
 npm run smoke-test
 ```
 
 To run end-to-end tests on the production environment:
-
 ```
 npm run test:e2e-prod
+```
+
+If a test has failed and you would like to debug a single test:
+```
+npm run test:e2e-debug --test test/e2e/workflows/guest-checkout.js
 ```
 
 ## Lighthouse tests

--- a/web/package.json
+++ b/web/package.json
@@ -147,6 +147,7 @@
     "test:all": "npm run lint && npm test -- --coverage",
     "test:check-lighthouse-score": "node tests/performance/lighthouse/check-lighthouse-score.js",
     "test:e2e": "cross-env NODE_ENV=test node ./node_modules/nightwatch/bin/runner.js -c ./tests/e2e/nightwatch-config.js --suiteRetries 1",
+    "test:e2e-debug": "cross-env NODE_ENV=debug BABEL_ENV=test node ./node_modules/nightwatch/bin/runner.js -c ./tests/e2e/nightwatch-config.js --suiteRetries 0",
     "test:e2e-prod": "cross-env NODE_ENV=production BABEL_ENV=test node ./node_modules/nightwatch/bin/runner.js -c ./tests/e2e/nightwatch-config.js --suiteRetries 1",
     "test:max-file-size": "node tests/performance/max-file-size.js",
     "test:pwa-prod": "bash ./tests/performance/lighthouse/lighthouse-prod.sh",

--- a/web/tests/e2e/page-objects/home.js
+++ b/web/tests/e2e/page-objects/home.js
@@ -32,6 +32,13 @@ Home.prototype.openBrowserToHomepage = function() {
         .assert.visible(selectors.wrapper)
 }
 
+Home.prototype.closeBrowser = function() {
+    if (ENV === 'debug') {
+        console.log('Debugging, not closing browser')
+    } else {
+        this.browser.end()
+    }
+}
 
 Home.prototype.navigateToProductList = function(PRODUCT_LIST_INDEX) {
     // Navigate from Home to ProductList

--- a/web/tests/e2e/page-objects/home.js
+++ b/web/tests/e2e/page-objects/home.js
@@ -1,6 +1,7 @@
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
 /* Copyright (c) 2017 Mobify Research & Development Inc. All rights reserved. */
 /* * *  *  * *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  *  * */
+const ENV = process.env.NODE_ENV || 'test'
 
 const selectors = {
     wrapper: '.t-home__container',
@@ -18,6 +19,19 @@ const Home = function(browser) {
     this.browser = browser
     this.selectors = selectors
 }
+
+Home.prototype.openBrowserToHomepage = function() {
+    if (ENV === 'production') {
+        this.browser.url(process.env.npm_package_siteUrl)
+    } else {
+        console.log('Running preview.')
+        this.browser.preview(process.env.npm_package_siteUrl, 'https://localhost:8443/loader.js')
+    }
+    this.browser
+        .waitForElementVisible(selectors.wrapper)
+        .assert.visible(selectors.wrapper)
+}
+
 
 Home.prototype.navigateToProductList = function(PRODUCT_LIST_INDEX) {
     // Navigate from Home to ProductList

--- a/web/tests/e2e/page-objects/home.js
+++ b/web/tests/e2e/page-objects/home.js
@@ -32,12 +32,13 @@ Home.prototype.openBrowserToHomepage = function() {
         .assert.visible(selectors.wrapper)
 }
 
-Home.prototype.closeBrowser = function(browser) {
+Home.prototype.closeBrowser = function() {
     if (ENV === 'debug') {
         console.log('Debugging, not closing browser')
     } else {
-        browser.end()
+        this.browser.end()
     }
+    return this
 }
 
 Home.prototype.navigateToProductList = function(PRODUCT_LIST_INDEX) {

--- a/web/tests/e2e/page-objects/home.js
+++ b/web/tests/e2e/page-objects/home.js
@@ -43,7 +43,7 @@ Home.prototype.closeBrowser = function() {
 Home.prototype.navigateToProductList = function(PRODUCT_LIST_INDEX) {
     // Navigate from Home to ProductList
     this.browser
-        .log('Navigating to ProductList')
+        .log(`Navigating to ProductList number: ${PRODUCT_LIST_INDEX}`)
         .waitForElementVisible(selectors.productListItem(PRODUCT_LIST_INDEX))
         .click(selectors.productListItem(PRODUCT_LIST_INDEX))
     return this

--- a/web/tests/e2e/page-objects/home.js
+++ b/web/tests/e2e/page-objects/home.js
@@ -32,11 +32,11 @@ Home.prototype.openBrowserToHomepage = function() {
         .assert.visible(selectors.wrapper)
 }
 
-Home.prototype.closeBrowser = function() {
+Home.prototype.closeBrowser = function(browser) {
     if (ENV === 'debug') {
         console.log('Debugging, not closing browser')
     } else {
-        this.browser.end()
+        browser.end()
     }
 }
 

--- a/web/tests/e2e/page-objects/product-list.js
+++ b/web/tests/e2e/page-objects/product-list.js
@@ -17,7 +17,7 @@ const ProductList = function(browser) {
 ProductList.prototype.navigateToProductDetails = function(productIndex) {
     // Navigate from ProductList to ProductDetails
     this.browser
-        .log(`Navigating to ProductList number: ${productIndex}`)
+        .log(`Navigating to ProductDetails number: ${productIndex}`)
         .waitForElementVisible(selectors.productDetailsItem(productIndex))
         .click(selectors.productDetailsItem(productIndex))
         .waitUntilMobified()

--- a/web/tests/e2e/page-objects/product-list.js
+++ b/web/tests/e2e/page-objects/product-list.js
@@ -17,7 +17,7 @@ const ProductList = function(browser) {
 ProductList.prototype.navigateToProductDetails = function(productIndex) {
     // Navigate from ProductList to ProductDetails
     this.browser
-        .log('Navigating to ProductDetails')
+        .log(`Navigating to ProductList number: ${productIndex}`)
         .waitForElementVisible(selectors.productDetailsItem(productIndex))
         .click(selectors.productDetailsItem(productIndex))
         .waitUntilMobified()

--- a/web/tests/e2e/workflows/guest-checkout.js
+++ b/web/tests/e2e/workflows/guest-checkout.js
@@ -19,7 +19,6 @@ let pushMessaging
 
 const PRODUCT_LIST_INDEX = process.env.PRODUCT_LIST_INDEX || 2
 const PRODUCT_INDEX = process.env.PRODUCT_INDEX || 1
-const ENV = process.env.NODE_ENV || 'test'
 
 export default {
     '@tags': ['checkout'],
@@ -33,8 +32,8 @@ export default {
         pushMessaging = new PushMessaging(browser)
     },
 
-    after: (browser) => {
-        browser.end()
+    after: () => {
+        Home.prototype.closeBrowser()
     },
 
     // The following tests are conducted in sequence within the same session.

--- a/web/tests/e2e/workflows/guest-checkout.js
+++ b/web/tests/e2e/workflows/guest-checkout.js
@@ -42,7 +42,7 @@ export default {
         home.openBrowserToHomepage()
     },
 
-    'Checkout - Guest - Navigate from Home to ProductList': (browser) => {
+    'Checkout - Guest - Step 2 - Navigate from Home to ProductList': (browser) => {
         home.navigateToProductList(PRODUCT_LIST_INDEX)
         browser
             .waitForElementVisible(productList.selectors.productListTemplateIdentifier)
@@ -53,18 +53,18 @@ export default {
         pushMessaging.dismissDefaultAsk()
     },
 
-    'Checkout - Guest - Navigate from ProductList to ProductDetails': (browser) => {
+    'Checkout - Guest - Step 3 - Navigate from ProductList to ProductDetails': (browser) => {
         productList.navigateToProductDetails(PRODUCT_INDEX)
         browser
             .waitForElementVisible(productDetails.selectors.productDetailsTemplateIdentifier)
             .assert.visible(productDetails.selectors.productDetailsTemplateIdentifier)
     },
 
-    'Checkout - Guest - Add item to Shopping Cart': () => {
+    'Checkout - Guest - Step 4 - Add item to Shopping Cart': () => {
         productDetails.addItemToCart()
     },
 
-    'Checkout - Guest - Navigate from ProductDetails to Cart': (browser) => {
+    'Checkout - Guest - Step 5 - Navigate from ProductDetails to Cart': (browser) => {
         if (productDetails.inStock) {
             productDetails.navigateToCart()
             browser
@@ -75,7 +75,7 @@ export default {
         }
     },
 
-    'Checkout - Guest - Navigate from Cart to Checkout': (browser) => {
+    'Checkout - Guest - Step 6 - Navigate from Cart to Checkout': (browser) => {
         if (productDetails.inStock) {
             cart.navigateToCheckout()
             browser
@@ -84,7 +84,7 @@ export default {
         }
     },
 
-    'Checkout - Guest - Fill out Guest Checkout Shipping Info form': (browser) => {
+    'Checkout - Guest - Step 7 - Fill out Guest Checkout Shipping Info form': (browser) => {
         if (productDetails.inStock) {
             checkout.fillShippingInfo()
             browser
@@ -95,7 +95,7 @@ export default {
         }
     },
 
-    'Checkout - Guest - Fill out Guest Checkout Payment Details form': (browser) => {
+    'Checkout - Guest - Step 8 - Fill out Guest Checkout Payment Details form': (browser) => {
         if (productDetails.inStock) {
             checkout.continueToPayment()
             checkout.fillPaymentInfo()
@@ -105,7 +105,7 @@ export default {
         }
     },
 
-    'Checkout - Guest - Verify Place Your Order button is visible': (browser) => {
+    'Checkout - Guest - Step 9 - Verify Place Your Order button is visible': (browser) => {
         if (productDetails.inStock) {
             browser
                 .waitForElementVisible(checkout.selectors.placeOrder)

--- a/web/tests/e2e/workflows/guest-checkout.js
+++ b/web/tests/e2e/workflows/guest-checkout.js
@@ -39,16 +39,8 @@ export default {
 
     // The following tests are conducted in sequence within the same session.
 
-    'Checkout - Guest - Navigate to Home': (browser) => {
-        if (ENV === 'production') {
-            browser.url(process.env.npm_package_siteUrl)
-        } else {
-            console.log('Running preview.')
-            browser.preview(process.env.npm_package_siteUrl, 'https://localhost:8443/loader.js')
-        }
-        browser
-            .waitForElementVisible(home.selectors.wrapper)
-            .assert.visible(home.selectors.wrapper)
+    'Checkout - Guest - Step 1 - Navigate to Home': () => {
+        home.openBrowserToHomepage()
     },
 
     'Checkout - Guest - Navigate from Home to ProductList': (browser) => {

--- a/web/tests/e2e/workflows/guest-checkout.js
+++ b/web/tests/e2e/workflows/guest-checkout.js
@@ -32,8 +32,8 @@ export default {
         pushMessaging = new PushMessaging(browser)
     },
 
-    after: () => {
-        Home.prototype.closeBrowser()
+    after: (browser) => {
+        Home.prototype.closeBrowser(browser)
     },
 
     // The following tests are conducted in sequence within the same session.

--- a/web/tests/e2e/workflows/guest-checkout.js
+++ b/web/tests/e2e/workflows/guest-checkout.js
@@ -32,8 +32,8 @@ export default {
         pushMessaging = new PushMessaging(browser)
     },
 
-    after: (browser) => {
-        Home.prototype.closeBrowser(browser)
+    after: () => {
+        home.closeBrowser()
     },
 
     // The following tests are conducted in sequence within the same session.

--- a/web/tests/e2e/workflows/home-example.js
+++ b/web/tests/e2e/workflows/home-example.js
@@ -5,7 +5,6 @@
 import Home from '../page-objects/home'
 
 let home
-const ENV = process.env.NODE_ENV || 'test'
 
 // On the homepage, at least the following skip
 // links should be present on the page...
@@ -20,8 +19,8 @@ export default {
         home = new Home(browser)
     },
 
-    after: (browser) => {
-        browser.end()
+    after: () => {
+        Home.prototype.closeBrowser()
     },
 
     'Home Page': () => {

--- a/web/tests/e2e/workflows/home-example.js
+++ b/web/tests/e2e/workflows/home-example.js
@@ -19,8 +19,8 @@ export default {
         home = new Home(browser)
     },
 
-    after: () => {
-        Home.prototype.closeBrowser()
+    after: (browser) => {
+        Home.prototype.closeBrowser(browser)
     },
 
     'Home Page': () => {

--- a/web/tests/e2e/workflows/home-example.js
+++ b/web/tests/e2e/workflows/home-example.js
@@ -19,8 +19,8 @@ export default {
         home = new Home(browser)
     },
 
-    after: (browser) => {
-        Home.prototype.closeBrowser(browser)
+    after: () => {
+        home.closeBrowser()
     },
 
     'Home Page': () => {

--- a/web/tests/e2e/workflows/home-example.js
+++ b/web/tests/e2e/workflows/home-example.js
@@ -24,16 +24,8 @@ export default {
         browser.end()
     },
 
-    'Home Page': (browser) => {
-        if (ENV === 'production') {
-            browser.url(process.env.npm_package_siteUrl)
-        } else {
-            console.log('Running preview.')
-            browser.preview(process.env.npm_package_siteUrl, 'https://localhost:8443/loader.js')
-        }
-        browser
-            .waitForElementVisible(home.selectors.wrapper)
-            .assert.visible(home.selectors.wrapper)
+    'Home Page': () => {
+        home.openBrowserToHomepage()
     },
 
     'Skip Links': (browser) => {

--- a/web/tests/e2e/workflows/push-subscribe.js
+++ b/web/tests/e2e/workflows/push-subscribe.js
@@ -28,11 +28,11 @@ export default {
         Home.prototype.closeBrowser()
     },
 
-    'Push Subscribe - Home': () => {
+    'Push Subscribe - Step 1 - Home': () => {
         home.openBrowserToHomepage()
     },
 
-    'Push Subscribe - Navigate and Accept Default Ask': (browser) => {
+    'Push Subscribe - Step 2 - Navigate and Accept Default Ask': (browser) => {
         home.navigateToProductList(PRODUCT_LIST_INDEX)
         browser.waitForElementVisible(productList.selectors.productDetailsItem(1))
 

--- a/web/tests/e2e/workflows/push-subscribe.js
+++ b/web/tests/e2e/workflows/push-subscribe.js
@@ -25,8 +25,8 @@ export default {
         browser.timeoutsAsyncScript(2000)
     },
 
-    after: (browser) => {
-        browser.end()
+    after: () => {
+        Home.prototype.closeBrowser()
     },
 
     'Push Subscribe - Home': () => {

--- a/web/tests/e2e/workflows/push-subscribe.js
+++ b/web/tests/e2e/workflows/push-subscribe.js
@@ -29,16 +29,8 @@ export default {
         browser.end()
     },
 
-    'Push Subscribe - Home': (browser) => {
-        if (ENV === 'production') {
-            browser.url(process.env.npm_package_siteUrl)
-        } else {
-            console.log('Running preview.')
-            browser.preview(process.env.npm_package_siteUrl, 'https://localhost:8443/loader.js')
-        }
-        browser
-            .waitForElementVisible(home.selectors.wrapper)
-            .assert.visible(home.selectors.wrapper)
+    'Push Subscribe - Home': () => {
+        home.openBrowserToHomepage()
     },
 
     'Push Subscribe - Navigate and Accept Default Ask': (browser) => {

--- a/web/tests/e2e/workflows/push-subscribe.js
+++ b/web/tests/e2e/workflows/push-subscribe.js
@@ -12,7 +12,6 @@ let productList
 let pushMessaging
 
 const PRODUCT_LIST_INDEX = process.env.PRODUCT_LIST_INDEX || 2
-const ENV = process.env.NODE_ENV || 'test'
 
 export default {
     '@tags': ['messaging'],

--- a/web/tests/e2e/workflows/push-subscribe.js
+++ b/web/tests/e2e/workflows/push-subscribe.js
@@ -24,8 +24,8 @@ export default {
         browser.timeoutsAsyncScript(2000)
     },
 
-    after: (browser) => {
-        Home.prototype.closeBrowser(browser)
+    after: () => {
+        home.closeBrowser()
     },
 
     'Push Subscribe - Step 1 - Home': () => {

--- a/web/tests/e2e/workflows/push-subscribe.js
+++ b/web/tests/e2e/workflows/push-subscribe.js
@@ -24,8 +24,8 @@ export default {
         browser.timeoutsAsyncScript(2000)
     },
 
-    after: () => {
-        Home.prototype.closeBrowser()
+    after: (browser) => {
+        Home.prototype.closeBrowser(browser)
     },
 
     'Push Subscribe - Step 1 - Home': () => {

--- a/web/tests/e2e/workflows/registered-checkout.js
+++ b/web/tests/e2e/workflows/registered-checkout.js
@@ -40,11 +40,11 @@ export default {
 
     // The following tests are conducted in sequence within the same session.
 
-    'Checkout - Registered - Navigate to Home': () => {
+    'Checkout - Registered - Step 1 - Navigate to Home': () => {
         home.openBrowserToHomepage()
     },
 
-    'Checkout - Registered - Navigate from Home to ProductList': (browser) => {
+    'Checkout - Registered - Step 2 - Navigate from Home to ProductList': (browser) => {
         home.navigateToProductList(PRODUCT_LIST_INDEX)
         browser
             .waitForElementVisible(productList.selectors.productListTemplateIdentifier)
@@ -55,18 +55,18 @@ export default {
         pushMessaging.dismissDefaultAsk()
     },
 
-    'Checkout - Registered - Navigate from ProductList to ProductDetails': (browser) => {
+    'Checkout - Registered - Step 3 - Navigate from ProductList to ProductDetails': (browser) => {
         productList.navigateToProductDetails(PRODUCT_INDEX)
         browser
             .waitForElementVisible(productDetails.selectors.productDetailsTemplateIdentifier)
             .assert.visible(productDetails.selectors.productDetailsTemplateIdentifier)
     },
 
-    'Checkout - Registered - Add item to Shopping Cart': () => {
+    'Checkout - Registered - Step 4 - Add item to Shopping Cart': () => {
         productDetails.addItemToCart()
     },
 
-    'Checkout - Registered - Navigate from ProductDetails to Cart': (browser) => {
+    'Checkout - Registered - Step 5 - Navigate from ProductDetails to Cart': (browser) => {
         if (productDetails.inStock) {
             productDetails.navigateToCart()
             browser
@@ -77,7 +77,7 @@ export default {
         }
     },
 
-    'Checkout - Registered - Navigate from Cart to Checkout': (browser) => {
+    'Checkout - Registered - Step 6 - Navigate from Cart to Checkout': (browser) => {
         if (productDetails.inStock) {
             cart.navigateToCheckout()
             browser
@@ -88,7 +88,7 @@ export default {
         }
     },
 
-    'Checkout - Registered - Continue to Registered Checkout': (browser) => {
+    'Checkout - Registered - Step 7 - Continue to Registered Checkout': (browser) => {
         if (productDetails.inStock) {
             checkout.continueAsRegistered()
             browser
@@ -97,14 +97,14 @@ export default {
         }
     },
 
-    'Checkout - Registered - Choose shipping info': (browser) => {
+    'Checkout - Registered - Step 8 - Choose shipping info': (browser) => {
         if (productDetails.inStock) {
             checkout.chooseShippingInfo()
             browser.waitForElementVisible(`${checkout.selectors.addressListOption} .pw--checked`)
         }
     },
 
-    'Checkout - Registered - Fill out Registered Checkout Payment Details form': (browser) => {
+    'Checkout - Registered - Step 9 - Fill out Registered Checkout Payment Details form': (browser) => {
         if (productDetails.inStock) {
             checkout.continueToPayment()
             checkout.fillPaymentInfo()
@@ -114,7 +114,7 @@ export default {
         }
     },
 
-    'Checkout - Registered - Verify Submit Order button is visible': (browser) => {
+    'Checkout - Registered - Step 10 - Verify Submit Order button is visible': (browser) => {
         if (productDetails.inStock) {
             browser
                 .waitForElementVisible(checkout.selectors.placeOrder)

--- a/web/tests/e2e/workflows/registered-checkout.js
+++ b/web/tests/e2e/workflows/registered-checkout.js
@@ -40,16 +40,8 @@ export default {
 
     // The following tests are conducted in sequence within the same session.
 
-    'Checkout - Registered - Navigate to Home': (browser) => {
-        if (ENV === 'production') {
-            browser.url(process.env.npm_package_siteUrl)
-        } else {
-            console.log('Running preview.')
-            browser.preview(process.env.npm_package_siteUrl, 'https://localhost:8443/loader.js')
-        }
-        browser
-            .waitForElementVisible(home.selectors.wrapper)
-            .assert.visible(home.selectors.wrapper)
+    'Checkout - Registered - Navigate to Home': () => {
+        home.openBrowserToHomepage()
     },
 
     'Checkout - Registered - Navigate from Home to ProductList': (browser) => {

--- a/web/tests/e2e/workflows/registered-checkout.js
+++ b/web/tests/e2e/workflows/registered-checkout.js
@@ -33,9 +33,9 @@ export default {
         pushMessaging = new PushMessaging(browser)
     },
 
-    after: (browser) => {
+    after: () => {
         // cart.removeItems()
-        browser.end()
+        Home.prototype.closeBrowser()
     },
 
     // The following tests are conducted in sequence within the same session.

--- a/web/tests/e2e/workflows/registered-checkout.js
+++ b/web/tests/e2e/workflows/registered-checkout.js
@@ -32,9 +32,9 @@ export default {
         pushMessaging = new PushMessaging(browser)
     },
 
-    after: (browser) => {
+    after: () => {
         // cart.removeItems()
-        Home.prototype.closeBrowser(browser)
+        home.closeBrowser()
     },
 
     // The following tests are conducted in sequence within the same session.

--- a/web/tests/e2e/workflows/registered-checkout.js
+++ b/web/tests/e2e/workflows/registered-checkout.js
@@ -19,7 +19,6 @@ let pushMessaging
 
 const PRODUCT_LIST_INDEX = process.env.PRODUCT_LIST_INDEX || 2
 const PRODUCT_INDEX = process.env.PRODUCT_INDEX || 1
-const ENV = process.env.NODE_ENV || 'test'
 
 export default {
     '@tags': ['checkout'],
@@ -33,9 +32,9 @@ export default {
         pushMessaging = new PushMessaging(browser)
     },
 
-    after: () => {
+    after: (browser) => {
         // cart.removeItems()
-        Home.prototype.closeBrowser()
+        Home.prototype.closeBrowser(browser)
     },
 
     // The following tests are conducted in sequence within the same session.


### PR DESCRIPTION
Tired to go through from homepage to checkout manually? Have a script but always having to comment out ''browser.end" is getting very annoying?
Yes. Even for QA. It's hard to debug via SSH as well because of this.  

Lets add a test command that DOESN'T close the browser at the end, even if it fails.

These tests will go from Homepage - Before you Place an Order on checkout.
We also open a new chrome session every-time so that's a plus, we start fresh.

## Changes
- package.json: add test:e2e-debug which sets a `debug ENV variable`
- Refactored Opening and Closing steps of tests into functions
- Add step numbers to the name of tests and console.log the ENV variable for easier debugging

## How to test-drive this PR
- Run `npm run dev`
- npm run test:e2e-debug --tests tests/e2e/workflows/guest-checkout.js
- npm run test:e2e-debug --tests tests/e2e/workflows/registered-checkout.js

Note that you should CTRL-Force Quit those browers you've opened when the tests end as they won't close themselves.

